### PR TITLE
feat: Generate the Reads-sections dynamically from the OverrideCycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ See [GitHub releases](https://github.com/mll-lab/php-utils/releases).
 
 ## Unreleased
 
+## v2.0.0
+
+### Changed
+
+- Generate the Reads-Sections dynamically from the OverrideCycles-part of the Samples-Section for Illumina NovaSeq Sample Sheets (V2)
+- OverrideCycles on BclSample not nullable
+
 ## v1.14.0
 
 ### Added

--- a/src/IlluminaSampleSheet/V2/BclConvert/BclConvertSection.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/BclConvertSection.php
@@ -2,7 +2,9 @@
 
 namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
 
+use Illuminate\Support\Collection;
 use MLL\Utils\IlluminaSampleSheet\Section;
+use MLL\Utils\IlluminaSampleSheet\V2\ReadsSection;
 
 class BclConvertSection implements Section
 {
@@ -24,5 +26,41 @@ class BclConvertSection implements Section
         ];
 
         return implode("\n", $bclConvertLines);
+    }
+
+    public function makeReadsSection(): ReadsSection
+    {
+        $dataRows = new Collection($this->dataSection->dataRows);
+
+        $countFromCycleTypeWithCount = fn (CycleTypeWithCount $cycleTypeWithCount) => $cycleTypeWithCount->count;
+
+        $read1Cycles = $dataRows->max(
+            fn (BclSample $dataRow) => (new Collection($dataRow->overrideCycles->read1->cycles)
+            )->sum($countFromCycleTypeWithCount)
+        );
+        $index1Cycles = $dataRows->max(
+            fn (BclSample $dataRow) => (new Collection($dataRow->overrideCycles->index1->cycles)
+            )->sum($countFromCycleTypeWithCount)
+        );
+
+        $index2Cycles = $dataRows->max(
+            fn (BclSample $dataRow) => $dataRow->overrideCycles->index2 instanceof OverrideCycle
+                ? (new Collection($dataRow->overrideCycles->index2->cycles))
+                    ->sum($countFromCycleTypeWithCount)
+                : null
+        );
+        $read2Cycles = $dataRows->max(
+            fn (BclSample $dataRow) => $dataRow->overrideCycles->read2 instanceof OverrideCycle
+                ? (new Collection($dataRow->overrideCycles->read2->cycles))
+                    ->sum($countFromCycleTypeWithCount)
+                : null
+        );
+
+        assert(is_int($read1Cycles));
+        assert(is_int($index1Cycles));
+        assert(is_int($read2Cycles) || is_null($read2Cycles));
+        assert(is_int($index2Cycles) || is_null($index2Cycles));
+
+        return new ReadsSection($read1Cycles, $index1Cycles, $read2Cycles, $index2Cycles);
     }
 }

--- a/src/IlluminaSampleSheet/V2/BclConvert/BclConvertSection.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/BclConvertSection.php
@@ -32,25 +32,25 @@ class BclConvertSection implements Section
     {
         $dataRows = new Collection($this->dataSection->dataRows);
 
-        $countFromCycleTypeWithCount = fn (CycleTypeWithCount $cycleTypeWithCount) => $cycleTypeWithCount->count;
+        $countFromCycleTypeWithCount = fn (CycleTypeWithCount $cycleTypeWithCount): int => $cycleTypeWithCount->count;
 
         $read1Cycles = $dataRows->max(
-            fn (BclSample $dataRow) => (new Collection($dataRow->overrideCycles->read1->cycles)
-            )->sum($countFromCycleTypeWithCount)
+            fn (BclSample $dataRow): int => (new Collection($dataRow->overrideCycles->read1->cycles))
+                ->sum($countFromCycleTypeWithCount)
         );
         $index1Cycles = $dataRows->max(
-            fn (BclSample $dataRow) => (new Collection($dataRow->overrideCycles->index1->cycles)
-            )->sum($countFromCycleTypeWithCount)
+            fn (BclSample $dataRow): int => (new Collection($dataRow->overrideCycles->index1->cycles))
+                ->sum($countFromCycleTypeWithCount)
         );
 
         $index2Cycles = $dataRows->max(
-            fn (BclSample $dataRow) => $dataRow->overrideCycles->index2 instanceof OverrideCycle
+            fn (BclSample $dataRow): ?int => $dataRow->overrideCycles->index2 instanceof OverrideCycle
                 ? (new Collection($dataRow->overrideCycles->index2->cycles))
                     ->sum($countFromCycleTypeWithCount)
                 : null
         );
         $read2Cycles = $dataRows->max(
-            fn (BclSample $dataRow) => $dataRow->overrideCycles->read2 instanceof OverrideCycle
+            fn (BclSample $dataRow): ?int => $dataRow->overrideCycles->read2 instanceof OverrideCycle
                 ? (new Collection($dataRow->overrideCycles->read2->cycles))
                     ->sum($countFromCycleTypeWithCount)
                 : null

--- a/src/IlluminaSampleSheet/V2/BclConvert/BclConvertSection.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/BclConvertSection.php
@@ -35,22 +35,22 @@ class BclConvertSection implements Section
         $countFromCycleTypeWithCount = fn (CycleTypeWithCount $cycleTypeWithCount): int => $cycleTypeWithCount->count;
 
         $read1Cycles = $dataRows->max(
-            fn (BclSample $dataRow): int => (new Collection($dataRow->overrideCycles->read1->cycles))
+            fn (BclSample $dataRow) => (new Collection($dataRow->overrideCycles->read1->cycles))
                 ->sum($countFromCycleTypeWithCount)
         );
         $index1Cycles = $dataRows->max(
-            fn (BclSample $dataRow): int => (new Collection($dataRow->overrideCycles->index1->cycles))
+            fn (BclSample $dataRow) => (new Collection($dataRow->overrideCycles->index1->cycles))
                 ->sum($countFromCycleTypeWithCount)
         );
 
         $index2Cycles = $dataRows->max(
-            fn (BclSample $dataRow): ?int => $dataRow->overrideCycles->index2 instanceof OverrideCycle
+            fn (BclSample $dataRow) => $dataRow->overrideCycles->index2 instanceof OverrideCycle
                 ? (new Collection($dataRow->overrideCycles->index2->cycles))
                     ->sum($countFromCycleTypeWithCount)
                 : null
         );
         $read2Cycles = $dataRows->max(
-            fn (BclSample $dataRow): ?int => $dataRow->overrideCycles->read2 instanceof OverrideCycle
+            fn (BclSample $dataRow) => $dataRow->overrideCycles->read2 instanceof OverrideCycle
                 ? (new Collection($dataRow->overrideCycles->read2->cycles))
                     ->sum($countFromCycleTypeWithCount)
                 : null

--- a/src/IlluminaSampleSheet/V2/BclConvert/BclSample.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/BclSample.php
@@ -13,7 +13,7 @@ class BclSample
 
     public ?string $index2 = null;
 
-    public ?string $overrideCycles = null;
+    public OverrideCycles $overrideCycles;
 
     public ?string $adapterRead1 = null;
 
@@ -41,7 +41,7 @@ class BclSample
             $this->sample_ID,
             $this->index,
             $this->index2,
-            $this->overrideCycles,
+            $this->overrideCycles->toString(),
             $this->adapterRead1,
             $this->adapterRead2,
             $this->barcodeMismatchesIndex1,

--- a/src/IlluminaSampleSheet/V2/BclConvert/BclSample.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/BclSample.php
@@ -11,9 +11,9 @@ class BclSample
 
     public string $index;
 
-    public OverrideCycles $overrideCycles;
-
     public ?string $index2 = null;
+
+    public OverrideCycles $overrideCycles;
 
     public ?string $adapterRead1 = null;
 

--- a/src/IlluminaSampleSheet/V2/BclConvert/BclSample.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/BclSample.php
@@ -26,11 +26,13 @@ class BclSample
     public function __construct(
         int $lane,
         string $sample_ID,
-        string $index
+        string $index,
+        OverrideCycles $overrideCycles
     ) {
         $this->lane = $lane;
         $this->sample_ID = $sample_ID;
         $this->index = $index;
+        $this->overrideCycles = $overrideCycles;
     }
 
     /** @return array<int|string> */

--- a/src/IlluminaSampleSheet/V2/BclConvert/BclSample.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/BclSample.php
@@ -11,9 +11,9 @@ class BclSample
 
     public string $index;
 
-    public ?string $index2 = null;
-
     public OverrideCycles $overrideCycles;
+
+    public ?string $index2 = null;
 
     public ?string $adapterRead1 = null;
 

--- a/src/IlluminaSampleSheet/V2/BclConvert/CycleType.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/CycleType.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
+
+class CycleType
+{
+    public const READ_CYCLE = 'Y';
+    public const TRIMMED_CYCLE = 'N';
+    public const UMI_CYCLE = 'U';
+    public const INDEX_CYCLE = 'I';
+
+    public string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function READ_CYCLE(): self
+    {
+        return new self(self::READ_CYCLE);
+    }
+
+    public static function TRIMMED_CYCLE(): self
+    {
+        return new self(self::TRIMMED_CYCLE);
+    }
+
+    public static function UMI_CYCLE(): self
+    {
+        return new self(self::UMI_CYCLE);
+    }
+
+    public static function INDEX_CYCLE(): self
+    {
+        return new self(self::INDEX_CYCLE);
+    }
+}

--- a/src/IlluminaSampleSheet/V2/BclConvert/CycleTypeWithCount.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/CycleTypeWithCount.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
+
+class CycleTypeWithCount
+{
+    private CycleType $cycleType;
+
+    public int $count;
+
+    public function __construct(CycleType $cycleType, int $count)
+    {
+        $this->cycleType = $cycleType;
+        $this->count = $count;
+    }
+
+    public function toString(): string
+    {
+        return $this->cycleType->value . $this->count;
+    }
+}

--- a/src/IlluminaSampleSheet/V2/BclConvert/CycleTypeWithCount.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/CycleTypeWithCount.php
@@ -4,7 +4,7 @@ namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
 
 class CycleTypeWithCount
 {
-    private CycleType $cycleType;
+    protected CycleType $cycleType;
 
     public int $count;
 

--- a/src/IlluminaSampleSheet/V2/BclConvert/DataSection.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/DataSection.php
@@ -7,7 +7,7 @@ use MLL\Utils\IlluminaSampleSheet\Section;
 class DataSection implements Section
 {
     /** @var array<BclSample> */
-    protected array $dataRows = [];
+    public array $dataRows = [];
 
     public function addSample(BclSample $bclSample): void
     {

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycle.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycle.php
@@ -16,7 +16,7 @@ class OverrideCycle
     public function toString(): string
     {
         return implode('', array_map(
-            fn (CycleTypeWithCount $cycle) => $cycle->toString(),
+            fn (CycleTypeWithCount $cycle): string => $cycle->toString(),
             $this->cycles
         ));
     }

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycle.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycle.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
+
+class OverrideCycle
+{
+    /** @var array<CycleTypeWithCount> */
+    public array $cycles;
+
+    /** @param array<CycleTypeWithCount> $firstCycle */
+    public function __construct(array $firstCycle)
+    {
+        $this->cycles = $firstCycle;
+    }
+
+    public function toString(): string
+    {
+        return implode('', array_map(
+            fn (CycleTypeWithCount $cycle) => $cycle->toString(),
+            $this->cycles
+        ));
+    }
+}

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
@@ -39,7 +39,7 @@ class OverrideCycles
     public function makeOverrideCycle(string $cycleString): OverrideCycle
     {
         \Safe\preg_match_all('/([YNUI]+)(\d+)/', $cycleString, $matches, PREG_SET_ORDER);
-        $result = [];
+
         if (count($matches) > 3) {
             throw new IlluminaSampleSheetException("Invalid Override Cycle Part. Should have less than 4 parts: {$cycleString}.");
         }
@@ -50,7 +50,7 @@ class OverrideCycles
 
         return new OverrideCycle(
             array_map(
-                fn ($match) => new CycleTypeWithCount(new CycleType($match[1]), (int) $match[2]),
+                fn (array $match) => new CycleTypeWithCount(new CycleType($match[1]), (int) $match[2]),
                 $matches
             )
         );

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
@@ -48,10 +48,11 @@ class OverrideCycles
             throw new IlluminaSampleSheetException("Invalid Override Cycle Part. Should have at least 1 part: {$cycleString}.");
         }
 
-        foreach ($matches as $match) {
-            $result[] = new CycleTypeWithCount(new CycleType($match[1]), (int) $match[2]);
-        }
-
-        return new OverrideCycle($result);
+        return new OverrideCycle(
+            array_map(
+                fn ($match) => new CycleTypeWithCount(new CycleType($match[1]), (int) $match[2]),
+                $matches
+            )
+        );
     }
 }

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
@@ -41,11 +41,11 @@ class OverrideCycles
         \Safe\preg_match_all('/([YNUI]+)(\d+)/', $cycleString, $matches, PREG_SET_ORDER);
         $result = [];
         if (count($matches) > 3) {
-            throw new IlluminaSampleSheetException("Invalid Override Cycle Part. Should have less than 4 parts :{$cycleString}");
+            throw new IlluminaSampleSheetException("Invalid Override Cycle Part. Should have less than 4 parts: {$cycleString}.");
         }
 
         if (count($matches) === 0) {
-            throw new IlluminaSampleSheetException("Invalid Override Cycle Part. Should have at least 1 part :{$cycleString}");
+            throw new IlluminaSampleSheetException("Invalid Override Cycle Part. Should have at least 1 part: {$cycleString}.");
         }
 
         foreach ($matches as $match) {

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
+
+use MLL\Utils\IlluminaSampleSheet\IlluminaSampleSheetException;
+
+class OverrideCycles
+{
+    public OverrideCycle $read1;
+
+    public OverrideCycle $index1;
+
+    public ?OverrideCycle $index2;
+
+    public ?OverrideCycle $read2;
+
+    public function __construct(string $read1, string $index1, ?string $index2, ?string $read2)
+    {
+        $this->read1 = $this->makeOverrideCycle($read1);
+        $this->index1 = $this->makeOverrideCycle($index1);
+        $this->index2 = $index2 !== null ? $this->makeOverrideCycle($index2) : null;
+        $this->read2 = $read2 !== null ? $this->makeOverrideCycle($read2) : null;
+    }
+
+    public function toString(): string
+    {
+        return implode(';', array_filter([
+            $this->read1->toString(),
+            $this->index1->toString(),
+            $this->index2 instanceof OverrideCycle
+                ? $this->index2->toString()
+                : null,
+            $this->read2 instanceof OverrideCycle
+                ? $this->read2->toString()
+                : null,
+        ]));
+    }
+
+    public function makeOverrideCycle(string $cycleString): OverrideCycle
+    {
+        \Safe\preg_match_all('/([YNUI]+)(\d+)/', $cycleString, $matches, PREG_SET_ORDER);
+        $result = [];
+        if (count($matches) > 3) {
+            throw new IlluminaSampleSheetException("Invalid Override Cycle Part. Should have less than 4 parts :{$cycleString}");
+        }
+
+        if (count($matches) === 0) {
+            throw new IlluminaSampleSheetException("Invalid Override Cycle Part. Should have at least 1 part :{$cycleString}");
+        }
+
+        foreach ($matches as $match) {
+            $result[] = new CycleTypeWithCount(new CycleType($match[1]), (int) $match[2]);
+        }
+
+        return new OverrideCycle($result);
+    }
+}

--- a/src/IlluminaSampleSheet/V2/NovaSeqXSampleSheet.php
+++ b/src/IlluminaSampleSheet/V2/NovaSeqXSampleSheet.php
@@ -9,12 +9,12 @@ class NovaSeqXSampleSheet extends SampleSheet
 {
     public function __construct(
         HeaderSection $header,
-        ReadsSection $reads,
         ?BclConvertSection $bclConvertSection
     ) {
         $this->addSection($header);
-        $this->addSection($reads);
+
         if (! is_null($bclConvertSection)) {
+            $this->addSection($bclConvertSection->makeReadsSection());
             $this->addSection($bclConvertSection);
         }
     }

--- a/src/IlluminaSampleSheet/V2/ReadsSection.php
+++ b/src/IlluminaSampleSheet/V2/ReadsSection.php
@@ -9,13 +9,13 @@ class ReadsSection implements Section
 {
     protected int $read1Cycles;
 
-    protected ?int $read2Cycles;
+    protected int $index1Cycles;
 
-    protected ?int $index1Cycles;
+    protected ?int $read2Cycles;
 
     protected ?int $index2Cycles;
 
-    public function __construct(int $read1Cycles, ?int $read2Cycles = null, ?int $index1Cycles = null, ?int $index2Cycles = null)
+    public function __construct(int $read1Cycles, int $index1Cycles, ?int $read2Cycles = null, ?int $index2Cycles = null)
     {
         if ($read1Cycles < 1) {
             throw new IlluminaSampleSheetException('Read1Cycles must be a positive integer.');
@@ -23,11 +23,11 @@ class ReadsSection implements Section
         if ($read2Cycles !== null && $read2Cycles < 1) {
             throw new IlluminaSampleSheetException('Read2Cycles must be a positive integer or null.');
         }
-        if ($index1Cycles !== null && ($index1Cycles < 6 || $index1Cycles > 12)) {
-            throw new IlluminaSampleSheetException('Index1Cycles must be between 6 and 12 or null.');
+        if ($index1Cycles < 6) {
+            throw new IlluminaSampleSheetException('Index1Cycles must be at least 6.');
         }
-        if ($index2Cycles !== null && ($index2Cycles < 6 || $index2Cycles > 12)) {
-            throw new IlluminaSampleSheetException('Index2Cycles must be between 6 and 12 or null.');
+        if ($index2Cycles !== null && ($index2Cycles < 6)) {
+            throw new IlluminaSampleSheetException('Index2Cycles must be at least 6.');
         }
         $this->read1Cycles = $read1Cycles;
         $this->read2Cycles = $read2Cycles;
@@ -43,9 +43,9 @@ class ReadsSection implements Section
         if ($this->read2Cycles !== null) {
             $readsLines[] = "Read2Cycles,{$this->read2Cycles}";
         }
-        if ($this->index1Cycles !== null) {
-            $readsLines[] = "Index1Cycles,{$this->index1Cycles}";
-        }
+
+        $readsLines[] = "Index1Cycles,{$this->index1Cycles}";
+
         if ($this->index2Cycles !== null) {
             $readsLines[] = "Index2Cycles,{$this->index2Cycles}";
         }

--- a/tests/IlluminaSampleSheet/V2/NovaSeqXCloudSampleSheetTest.php
+++ b/tests/IlluminaSampleSheet/V2/NovaSeqXCloudSampleSheetTest.php
@@ -25,23 +25,23 @@ final class NovaSeqXCloudSampleSheetTest extends TestCase
 
         $bclConvertDataSection = new DataSection();
 
-        $bclSample = new BclSample(1, 'Sample1', 'Index1');
+        $overrideCycles = new OverrideCycles('U7N1Y143', 'I8', 'I8', 'U7N1Y143');
+        $bclSample = new BclSample(1, 'Sample1', 'Index1', $overrideCycles);
         $bclSample->index2 = 'Index2';
-        $bclSample->overrideCycles = new OverrideCycles('U7N1Y143', 'I8', 'I8', 'U7N1Y143');
 
         $bclSample->adapterRead1 = 'Adapter1';
         $bclSample->adapterRead2 = 'Adapter2';
 
-        $bclSample1 = new BclSample(2, 'Sample2', 'Index3');
+        $overrideCycles1 = new OverrideCycles('Y151', 'I8', 'U10', 'Y151');
+        $bclSample1 = new BclSample(2, 'Sample2', 'Index3', $overrideCycles1);
         $bclSample1->index2 = 'Index4';
-        $bclSample1->overrideCycles = new OverrideCycles('Y151', 'I8', 'U10', 'Y151');
 
         $bclSample1->adapterRead1 = 'Adapter3';
         $bclSample1->adapterRead2 = 'Adapter4';
 
-        $bclSample2 = new BclSample(3, 'Sample3', 'Index5');
+        $overrideCycles2 = new OverrideCycles('Y151', 'I8', 'I8', 'U10N12Y127');
+        $bclSample2 = new BclSample(3, 'Sample3', 'Index5', $overrideCycles2);
         $bclSample2->index2 = 'Index6';
-        $bclSample2->overrideCycles = new OverrideCycles('Y151', 'I8', 'I8', 'U10N12Y127');
 
         $bclSample2->adapterRead1 = 'Adapter5';
         $bclSample2->adapterRead2 = 'Adapter6';

--- a/tests/IlluminaSampleSheet/V2/NovaSeqXCloudSampleSheetTest.php
+++ b/tests/IlluminaSampleSheet/V2/NovaSeqXCloudSampleSheetTest.php
@@ -5,11 +5,11 @@ namespace MLL\Utils\Tests\IlluminaSampleSheet\V2;
 use MLL\Utils\IlluminaSampleSheet\V2\BclConvert\BclConvertSection;
 use MLL\Utils\IlluminaSampleSheet\V2\BclConvert\BclSample;
 use MLL\Utils\IlluminaSampleSheet\V2\BclConvert\DataSection;
+use MLL\Utils\IlluminaSampleSheet\V2\BclConvert\OverrideCycles;
 use MLL\Utils\IlluminaSampleSheet\V2\BclConvert\SettingsSection;
 use MLL\Utils\IlluminaSampleSheet\V2\Enums\FastQCompressionFormat;
 use MLL\Utils\IlluminaSampleSheet\V2\HeaderSection;
 use MLL\Utils\IlluminaSampleSheet\V2\NovaSeqXSampleSheet;
-use MLL\Utils\IlluminaSampleSheet\V2\ReadsSection;
 use PHPUnit\Framework\TestCase;
 
 final class NovaSeqXCloudSampleSheetTest extends TestCase
@@ -20,13 +20,6 @@ final class NovaSeqXCloudSampleSheetTest extends TestCase
         $headerSection->instrumentPlatform = 'NovaSeqXSeries';
         $headerSection->setCustomParam('IndexOrientation', 'Orientation1');
 
-        $readsSection = new ReadsSection(
-            100,
-            101,
-            10,
-            11
-        );
-
         $bclConvertSettingsSection = new SettingsSection('1.0.0', FastQCompressionFormat::GZIP());
         $bclConvertSettingsSection->trimUMI = false;
 
@@ -34,19 +27,22 @@ final class NovaSeqXCloudSampleSheetTest extends TestCase
 
         $bclSample = new BclSample(1, 'Sample1', 'Index1');
         $bclSample->index2 = 'Index2';
-        $bclSample->overrideCycles = 'Cycles1';
+        $bclSample->overrideCycles = new OverrideCycles('U7N1Y143', 'I8', 'I8', 'U7N1Y143');
+
         $bclSample->adapterRead1 = 'Adapter1';
         $bclSample->adapterRead2 = 'Adapter2';
 
         $bclSample1 = new BclSample(2, 'Sample2', 'Index3');
         $bclSample1->index2 = 'Index4';
-        $bclSample1->overrideCycles = 'Cycles2';
+        $bclSample1->overrideCycles = new OverrideCycles('Y151', 'I8', 'U10', 'Y151');
+
         $bclSample1->adapterRead1 = 'Adapter3';
         $bclSample1->adapterRead2 = 'Adapter4';
 
         $bclSample2 = new BclSample(3, 'Sample3', 'Index5');
         $bclSample2->index2 = 'Index6';
-        $bclSample2->overrideCycles = 'Cycles3';
+        $bclSample2->overrideCycles = new OverrideCycles('Y151', 'I8', 'I8', 'U10N12Y127');
+
         $bclSample2->adapterRead1 = 'Adapter5';
         $bclSample2->adapterRead2 = 'Adapter6';
 
@@ -58,7 +54,6 @@ final class NovaSeqXCloudSampleSheetTest extends TestCase
 
         $novaSeqXCloudSampleSheet = new NovaSeqXSampleSheet(
             $headerSection,
-            $readsSection,
             $bclConvertSection,
         );
 
@@ -69,10 +64,10 @@ InstrumentPlatform,NovaSeqXSeries
 Custom_IndexOrientation,Orientation1
 
 [Reads]
-Read1Cycles,100
-Read2Cycles,101
-Index1Cycles,10
-Index2Cycles,11
+Read1Cycles,151
+Read2Cycles,151
+Index1Cycles,8
+Index2Cycles,10
 
 [BCLConvert_Settings]
 SoftwareVersion,1.0.0
@@ -81,9 +76,9 @@ TrimUMI,0
 
 [BCLConvert_Data]
 Lane,Sample_ID,Index,Index2,OverrideCycles,AdapterRead1,AdapterRead2
-1,Sample1,Index1,Index2,Cycles1,Adapter1,Adapter2
-2,Sample2,Index3,Index4,Cycles2,Adapter3,Adapter4
-3,Sample3,Index5,Index6,Cycles3,Adapter5,Adapter6
+1,Sample1,Index1,Index2,U7N1Y143;I8;I8;U7N1Y143,Adapter1,Adapter2
+2,Sample2,Index3,Index4,Y151;I8;U10;Y151,Adapter3,Adapter4
+3,Sample3,Index5,Index6,Y151;I8;I8;U10N12Y127,Adapter5,Adapter6
 ';
 
         self::assertSame($expected, $novaSeqXCloudSampleSheet->toString());


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Breaking changes**

- Generate the Reads-Sections dynamically from the OverrideCycles-part of the Samples-Section for Illumina NovaSeq Sample Sheets (V2)
- OverrideCycles on BclSample not nullable
