### PR TITLE
fix: override cycles must grow to max of all samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ See [GitHub releases](https://github.com/mll-lab/php-utils/releases).
 
 ## Unreleased
 
+## v2.2.1
+
+### Changed
+
+- All OverrideCycle total counts on DataSection must grow to the Reads-Sections maximum value by adding the N-tag
+
 ## v2.2.0
 
 ### Added

--- a/src/IlluminaSampleSheet/V2/BclConvert/BclConvertSection.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/BclConvertSection.php
@@ -2,7 +2,6 @@
 
 namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
 
-use Illuminate\Support\Collection;
 use MLL\Utils\IlluminaSampleSheet\Section;
 use MLL\Utils\IlluminaSampleSheet\V2\ReadsSection;
 
@@ -30,37 +29,6 @@ class BclConvertSection implements Section
 
     public function makeReadsSection(): ReadsSection
     {
-        $dataRows = new Collection($this->dataSection->dataRows);
-
-        $countFromCycleTypeWithCount = fn (CycleTypeWithCount $cycleTypeWithCount): int => $cycleTypeWithCount->count;
-
-        $read1Cycles = $dataRows->max(
-            fn (BclSample $dataRow) => (new Collection($dataRow->overrideCycles->read1->cycles))
-                ->sum($countFromCycleTypeWithCount)
-        );
-        $index1Cycles = $dataRows->max(
-            fn (BclSample $dataRow) => (new Collection($dataRow->overrideCycles->index1->cycles))
-                ->sum($countFromCycleTypeWithCount)
-        );
-
-        $index2Cycles = $dataRows->max(
-            fn (BclSample $dataRow) => $dataRow->overrideCycles->index2 instanceof OverrideCycle
-                ? (new Collection($dataRow->overrideCycles->index2->cycles))
-                    ->sum($countFromCycleTypeWithCount)
-                : null
-        );
-        $read2Cycles = $dataRows->max(
-            fn (BclSample $dataRow) => $dataRow->overrideCycles->read2 instanceof OverrideCycle
-                ? (new Collection($dataRow->overrideCycles->read2->cycles))
-                    ->sum($countFromCycleTypeWithCount)
-                : null
-        );
-
-        assert(is_int($read1Cycles));
-        assert(is_int($index1Cycles));
-        assert(is_int($read2Cycles) || is_null($read2Cycles));
-        assert(is_int($index2Cycles) || is_null($index2Cycles));
-
-        return new ReadsSection($read1Cycles, $index1Cycles, $read2Cycles, $index2Cycles);
+        return $this->dataSection->makeReadsSection();
     }
 }

--- a/src/IlluminaSampleSheet/V2/BclConvert/DataSection.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/DataSection.php
@@ -70,7 +70,10 @@ class DataSection implements Section
     public function maxRead1Cycles(): int
     {
         $max = $this->dataRows
-            ->max(fn (BclSample $dataRow) => $dataRow->overrideCycles->read1->sumCountOfAllCycles());
+            ->max(fn (BclSample $dataRow): int => $dataRow
+                ->overrideCycles
+                ->read1
+                ->sumCountOfAllCycles());
         assert(is_int($max));
 
         return $max;
@@ -79,11 +82,10 @@ class DataSection implements Section
     public function maxRead2Cycles(): ?int
     {
         $max = $this->dataRows->max(
-            fn (BclSample $dataRow) => $dataRow->overrideCycles->read2 instanceof OverrideCycle
+            fn (BclSample $dataRow): ?int => $dataRow->overrideCycles->read2 instanceof OverrideCycle
                 ? $dataRow->overrideCycles->read2->sumCountOfAllCycles()
                 : null
         );
-
         assert(is_int($max) || is_null($max));
 
         return $max;
@@ -92,7 +94,10 @@ class DataSection implements Section
     public function maxIndex1Cycles(): int
     {
         $index1Cycles = $this->dataRows
-            ->max(fn (BclSample $dataRow) => $dataRow->overrideCycles->index1->sumCountOfAllCycles());
+            ->max(fn (BclSample $dataRow): int => $dataRow
+                ->overrideCycles
+                ->index1
+                ->sumCountOfAllCycles());
         assert(is_int($index1Cycles));
 
         return $index1Cycles;
@@ -101,11 +106,10 @@ class DataSection implements Section
     public function maxIndex2Cycles(): ?int
     {
         $index2Cycles = $this->dataRows->max(
-            fn (BclSample $dataRow) => $dataRow->overrideCycles->index2 instanceof OverrideCycle
+            fn (BclSample $dataRow): ?int => $dataRow->overrideCycles->index2 instanceof OverrideCycle
                 ? $dataRow->overrideCycles->index2->sumCountOfAllCycles()
                 : null
         );
-
         assert(is_int($index2Cycles) || is_null($index2Cycles));
 
         return $index2Cycles;

--- a/src/IlluminaSampleSheet/V2/BclConvert/DataSection.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/DataSection.php
@@ -2,16 +2,23 @@
 
 namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
 
+use Illuminate\Support\Collection;
 use MLL\Utils\IlluminaSampleSheet\Section;
+use MLL\Utils\IlluminaSampleSheet\V2\ReadsSection;
 
 class DataSection implements Section
 {
-    /** @var array<BclSample> */
-    public array $dataRows = [];
+    /** @var Collection<int, BclSample> */
+    public Collection $dataRows;
+
+    public function __construct()
+    {
+        $this->dataRows = new Collection();
+    }
 
     public function addSample(BclSample $bclSample): void
     {
-        $this->dataRows[] = $bclSample;
+        $this->dataRows->add($bclSample);
     }
 
     public function convertSectionToString(): string
@@ -48,5 +55,59 @@ class DataSection implements Section
         $samplePropertiesOfFirstSample = array_map(fn (string $value) => ucfirst($value), $samplePropertiesOfFirstSample);
 
         return implode(',', $samplePropertiesOfFirstSample);
+    }
+
+    public function makeReadsSection(): ReadsSection
+    {
+        return new ReadsSection(
+            $this->maxRead1Cycles(),
+            $this->maxIndex1Cycles(),
+            $this->maxRead2Cycles(),
+            $this->maxIndex2Cycles()
+        );
+    }
+
+    public function maxRead1Cycles(): int
+    {
+        $max = $this->dataRows
+            ->max(fn (BclSample $dataRow) => $dataRow->overrideCycles->read1->sumCountOfAllCycles());
+        assert(is_int($max));
+
+        return $max;
+    }
+
+    public function maxRead2Cycles(): ?int
+    {
+        $max = $this->dataRows->max(
+            fn (BclSample $dataRow) => $dataRow->overrideCycles->read2 instanceof OverrideCycle
+                ? $dataRow->overrideCycles->read2->sumCountOfAllCycles()
+                : null
+        );
+
+        assert(is_int($max) || is_null($max));
+
+        return $max;
+    }
+
+    public function maxIndex1Cycles(): int
+    {
+        $index1Cycles = $this->dataRows
+            ->max(fn (BclSample $dataRow) => $dataRow->overrideCycles->index1->sumCountOfAllCycles());
+        assert(is_int($index1Cycles));
+
+        return $index1Cycles;
+    }
+
+    public function maxIndex2Cycles(): ?int
+    {
+        $index2Cycles = $this->dataRows->max(
+            fn (BclSample $dataRow) => $dataRow->overrideCycles->index2 instanceof OverrideCycle
+                ? $dataRow->overrideCycles->index2->sumCountOfAllCycles()
+                : null
+        );
+
+        assert(is_int($index2Cycles) || is_null($index2Cycles));
+
+        return $index2Cycles;
     }
 }

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycle.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycle.php
@@ -37,6 +37,11 @@ class OverrideCycle
 
     public function sumCountOfAllCycles(): int
     {
-        return array_sum(array_map(fn (CycleTypeWithCount $cycleTypeWithCount): int => $cycleTypeWithCount->count, $this->cycles));
+        return array_sum(
+            array_map(
+                fn (CycleTypeWithCount $cycleTypeWithCount): int => $cycleTypeWithCount->count,
+                $this->cycles
+            )
+        );
     }
 }

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycle.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycle.php
@@ -7,17 +7,36 @@ class OverrideCycle
     /** @var array<CycleTypeWithCount> */
     public array $cycles;
 
-    /** @param array<CycleTypeWithCount> $firstCycle */
-    public function __construct(array $firstCycle)
+    /** @param array<CycleTypeWithCount> $cycles */
+    public function __construct(array $cycles)
     {
-        $this->cycles = $firstCycle;
+        $this->cycles = $cycles;
     }
 
-    public function toString(): string
+    /** @param bool|null $isSecondIndexAndForwardDirection null if it is not the secondIndex, true if it is the secondIndex and forwardDirection, false if it is the secondIndex and reverseDirection */
+    public function toString(int $fillUpToMax, ?bool $isSecondIndexAndForwardDirection): string
     {
-        return implode('', array_map(
+        $countOfAllCycleTypes = $this->sumCountOfAllCycles();
+        assert($countOfAllCycleTypes <= $fillUpToMax, 'The sum of all cycle types must be less than or equal to the fill up to max value.');
+
+        $rawOverrideCycle = implode('', array_map(
             fn (CycleTypeWithCount $cycle): string => $cycle->toString(),
             $this->cycles
         ));
+
+        if ($countOfAllCycleTypes === $fillUpToMax) {
+            return $rawOverrideCycle;
+        }
+
+        $remainingCycles = 'N' . ($fillUpToMax - $countOfAllCycleTypes);
+
+        return (bool) $isSecondIndexAndForwardDirection
+            ? $remainingCycles . $rawOverrideCycle
+            : $rawOverrideCycle . $remainingCycles;
+    }
+
+    public function sumCountOfAllCycles(): int
+    {
+        return array_sum(array_map(fn (CycleTypeWithCount $cycleTypeWithCount): int => $cycleTypeWithCount->count, $this->cycles));
     }
 }

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
@@ -70,5 +70,4 @@ class OverrideCycles
             )
         );
     }
-
 }

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
@@ -3,6 +3,7 @@
 namespace MLL\Utils\IlluminaSampleSheet\V2\BclConvert;
 
 use MLL\Utils\IlluminaSampleSheet\IlluminaSampleSheetException;
+use MLL\Utils\IlluminaSampleSheet\V2\HeaderSection;
 
 class OverrideCycles
 {
@@ -14,24 +15,40 @@ class OverrideCycles
 
     public ?OverrideCycle $read2;
 
-    public function __construct(string $read1, string $index1, ?string $index2, ?string $read2)
+    private DataSection $dataSection;
+
+    public function __construct(DataSection $dataSection, string $read1, string $index1, ?string $index2, ?string $read2)
     {
         $this->read1 = $this->makeOverrideCycle($read1);
         $this->index1 = $this->makeOverrideCycle($index1);
         $this->index2 = $index2 !== null ? $this->makeOverrideCycle($index2) : null;
         $this->read2 = $read2 !== null ? $this->makeOverrideCycle($read2) : null;
+        $this->dataSection = $dataSection;
     }
 
     public function toString(): string
     {
+        $secondIndexIsForward = HeaderSection::indexOrientation() === HeaderSection::INDEX_ORIENTATION_FORWARD;
+
+        $dataSection = $this->dataSection;
+
+        if ($this->index2 instanceof OverrideCycle) {
+            $maxIndex2Cycles = $dataSection->maxIndex2Cycles();
+            if ($maxIndex2Cycles === null) {
+                throw new IlluminaSampleSheetException('MaxIndex2Cycles is required when Index2 is set.');
+            }
+
+            $index2 = $this->index2->toString($maxIndex2Cycles, $secondIndexIsForward);
+        } else {
+            $index2 = null;
+        }
+
         return implode(';', array_filter([
-            $this->read1->toString(),
-            $this->index1->toString(),
-            $this->index2 instanceof OverrideCycle
-                ? $this->index2->toString()
-                : null,
+            $this->read1->toString($dataSection->maxRead1Cycles(), null),
+            $this->index1->toString($dataSection->maxIndex1Cycles(), null),
+            $index2,
             $this->read2 instanceof OverrideCycle
-                ? $this->read2->toString()
+                ? $this->read2->toString($dataSection->maxRead1Cycles(), null)
                 : null,
         ]));
     }

--- a/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/OverrideCycles.php
@@ -28,8 +28,6 @@ class OverrideCycles
 
     public function toString(): string
     {
-        $secondIndexIsForward = HeaderSection::indexOrientation() === HeaderSection::INDEX_ORIENTATION_FORWARD;
-
         $dataSection = $this->dataSection;
 
         if ($this->index2 instanceof OverrideCycle) {
@@ -38,7 +36,7 @@ class OverrideCycles
                 throw new IlluminaSampleSheetException('MaxIndex2Cycles is required when Index2 is set.');
             }
 
-            $index2 = $this->index2->toString($maxIndex2Cycles, $secondIndexIsForward);
+            $index2 = $this->index2->toString($maxIndex2Cycles, HeaderSection::isForwardIndexOrientation());
         } else {
             $index2 = null;
         }
@@ -72,4 +70,5 @@ class OverrideCycles
             )
         );
     }
+
 }

--- a/src/IlluminaSampleSheet/V2/HeaderSection.php
+++ b/src/IlluminaSampleSheet/V2/HeaderSection.php
@@ -7,6 +7,7 @@ use MLL\Utils\IlluminaSampleSheet\Section;
 class HeaderSection implements Section
 {
     protected const FILE_FORMAT_VERSION = '2';
+    public const INDEX_ORIENTATION_FORWARD = 'Forward';
 
     protected string $fileFormatVersion = self::FILE_FORMAT_VERSION;
 
@@ -33,10 +34,12 @@ class HeaderSection implements Section
 
     public function convertSectionToString(): string
     {
+        $indexOrientation = self::indexOrientation();
         $headerLines = [
             '[Header]',
             "FileFormatVersion,{$this->fileFormatVersion}",
             "RunName,{$this->runName}",
+            "IndexOrientation,{$indexOrientation}",
         ];
         if (! is_null($this->runDescription)) {
             $headerLines[] = "RunDescription,{$this->runDescription}";
@@ -52,5 +55,13 @@ class HeaderSection implements Section
         }
 
         return implode("\n", $headerLines) . "\n";
+    }
+
+    public static function indexOrientation(): string
+    {
+        // only support the default IndexOrientation,Forward for now.
+        // Added method to explicitly display than this flag
+        // influences the Index2 in the OverrideCycles
+        return self::INDEX_ORIENTATION_FORWARD;
     }
 }

--- a/src/IlluminaSampleSheet/V2/HeaderSection.php
+++ b/src/IlluminaSampleSheet/V2/HeaderSection.php
@@ -59,9 +59,8 @@ class HeaderSection implements Section
 
     public static function indexOrientation(): string
     {
-        // only support the default IndexOrientation,Forward for now.
-        // Added method to explicitly display than this flag
-        // influences the Index2 in the OverrideCycles
+        // Only support the default IndexOrientation (Forward) for now.
+        // Added method to explicitly display that this flag influences Index2 in OverrideCycles.
         return self::INDEX_ORIENTATION_FORWARD;
     }
 }

--- a/src/IlluminaSampleSheet/V2/HeaderSection.php
+++ b/src/IlluminaSampleSheet/V2/HeaderSection.php
@@ -27,6 +27,12 @@ class HeaderSection implements Section
         $this->runName = $runName;
     }
 
+    public static function isForwardIndexOrientation(): bool
+    {
+        // Added this static method to explicitly display that this flag influences Index2 in OverrideCycles.
+        return HeaderSection::indexOrientation() === HeaderSection::INDEX_ORIENTATION_FORWARD;
+    }
+
     public function setCustomParam(string $paramName, string $paramValue): void
     {
         $this->customParams['Custom_' . $paramName] = $paramValue;
@@ -60,7 +66,6 @@ class HeaderSection implements Section
     public static function indexOrientation(): string
     {
         // Only support the default IndexOrientation (Forward) for now.
-        // Added method to explicitly display that this flag influences Index2 in OverrideCycles.
         return self::INDEX_ORIENTATION_FORWARD;
     }
 }

--- a/tests/BavarianHolidaysTest.php
+++ b/tests/BavarianHolidaysTest.php
@@ -4,6 +4,7 @@ namespace MLL\Utils\Tests;
 
 use Carbon\Carbon;
 use MLL\Utils\BavarianHolidays;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class BavarianHolidaysTest extends TestCase
@@ -15,24 +16,24 @@ final class BavarianHolidaysTest extends TestCase
         self::assertSame(BavarianHolidays::OSTERSONNTAG, BavarianHolidays::nameHoliday(self::easterSunday2019()));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('businessDays')]
     /** @dataProvider businessDays */
+    #[DataProvider('businessDays')]
     public function testBusinessDays(Carbon $businessDay): void
     {
         self::assertTrue(BavarianHolidays::isBusinessDay($businessDay));
         self::assertFalse(BavarianHolidays::isHoliday($businessDay));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('holidays')]
     /** @dataProvider holidays */
+    #[DataProvider('holidays')]
     public function testHolidays(Carbon $holiday): void
     {
         self::assertFalse(BavarianHolidays::isBusinessDay($holiday));
         self::assertTrue(BavarianHolidays::isHoliday($holiday));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('weekend')]
     /** @dataProvider weekend */
+    #[DataProvider('weekend')]
     public function testWeekend(Carbon $weekend): void
     {
         self::assertFalse(BavarianHolidays::isBusinessDay($weekend));

--- a/tests/CSVArrayTest.php
+++ b/tests/CSVArrayTest.php
@@ -3,6 +3,7 @@
 namespace MLL\Utils\Tests;
 
 use MLL\Utils\CSVArray;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /** @phpstan-import-type CSVPrimitive from CSVArray */
@@ -46,7 +47,7 @@ final class CSVArrayTest extends TestCase
      *
      * @param array<int, array<string, string>> $array
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('csvAndArrayStringValues')]
+    #[DataProvider('csvAndArrayStringValues')]
     public function testStringValues(string $csv, array $array): void
     {
         self::assertSame($array, CSVArray::toArray($csv));

--- a/tests/IlluminaSampleSheet/V1/DualIndexTest.php
+++ b/tests/IlluminaSampleSheet/V1/DualIndexTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 class DualIndexTest extends TestCase
 {
     /** @dataProvider provideValidDualIndexes */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideValidDualIndexes')]
     public function testValidate(
         string $i7IndexID,
         string $index,

--- a/tests/IlluminaSampleSheet/V1/DualIndexTest.php
+++ b/tests/IlluminaSampleSheet/V1/DualIndexTest.php
@@ -4,12 +4,13 @@ namespace MLL\Utils\Tests\IlluminaSampleSheet\V1;
 
 use MLL\Utils\IlluminaSampleSheet\IlluminaSampleSheetException;
 use MLL\Utils\IlluminaSampleSheet\V1\DualIndex;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class DualIndexTest extends TestCase
 {
     /** @dataProvider provideValidDualIndexes */
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideValidDualIndexes')]
+    #[DataProvider('provideValidDualIndexes')]
     public function testValidate(
         string $i7IndexID,
         string $index,

--- a/tests/IlluminaSampleSheet/V2/NovaSeqXCloudSampleSheetTest.php
+++ b/tests/IlluminaSampleSheet/V2/NovaSeqXCloudSampleSheetTest.php
@@ -53,7 +53,7 @@ final class NovaSeqXCloudSampleSheetTest extends TestCase
         $bclSample3->adapterRead1 = 'Adapter5';
         $bclSample3->adapterRead2 = 'Adapter6';
 
-        $overrideCycles4 = new OverrideCycles($bclConvertDataSection, 'U5N2Y94', 'I8', 'I8', 'U5N2Y94');
+        $overrideCycles4 = new OverrideCycles($bclConvertDataSection, 'U5N2Y94', 'I6', 'I8', 'U5N2Y94');
         $bclSample4 = new BclSample(6, 'Sample5', 'Index5', $overrideCycles4);
         $bclSample4->index2 = 'Index6';
 
@@ -97,7 +97,7 @@ Lane,Sample_ID,Index,Index2,OverrideCycles,AdapterRead1,AdapterRead2
 2,Sample2,Index3,Index4,Y151;I8;U10;Y151,Adapter3,Adapter4
 3,Sample3,Index5,Index6,Y151;I8;N2I8;U10N12Y127N2,Adapter5,Adapter6
 8,Sample4,Index5,Index6,Y101N50;I8;N2I8;Y101N50,Adapter5,Adapter6
-6,Sample5,Index5,Index6,U5N2Y94N50;I8;N2I8;U5N2Y94N50,Adapter5,Adapter6
+6,Sample5,Index5,Index6,U5N2Y94N50;I6N2;N2I8;U5N2Y94N50,Adapter5,Adapter6
 ';
 
         self::assertSame($expected, $novaSeqXCloudSampleSheet->toString());

--- a/tests/IlluminaSampleSheet/V2/NovaSeqXCloudSampleSheetTest.php
+++ b/tests/IlluminaSampleSheet/V2/NovaSeqXCloudSampleSheetTest.php
@@ -18,37 +18,53 @@ final class NovaSeqXCloudSampleSheetTest extends TestCase
     {
         $headerSection = new HeaderSection('Run1');
         $headerSection->instrumentPlatform = 'NovaSeqXSeries';
-        $headerSection->setCustomParam('IndexOrientation', 'Orientation1');
+        $headerSection->setCustomParam('TestKey', 'TestValue');
 
         $bclConvertSettingsSection = new SettingsSection('1.0.0', FastQCompressionFormat::GZIP());
         $bclConvertSettingsSection->trimUMI = false;
 
         $bclConvertDataSection = new DataSection();
 
-        $overrideCycles = new OverrideCycles('U7N1Y143', 'I8', 'I8', 'U7N1Y143');
+        $overrideCycles = new OverrideCycles($bclConvertDataSection, 'U7N1Y143', 'I8', 'I8', 'U7N1Y143');
         $bclSample = new BclSample(1, 'Sample1', 'Index1', $overrideCycles);
         $bclSample->index2 = 'Index2';
 
         $bclSample->adapterRead1 = 'Adapter1';
         $bclSample->adapterRead2 = 'Adapter2';
 
-        $overrideCycles1 = new OverrideCycles('Y151', 'I8', 'U10', 'Y151');
+        $overrideCycles1 = new OverrideCycles($bclConvertDataSection, 'Y151', 'I8', 'U10', 'Y151');
         $bclSample1 = new BclSample(2, 'Sample2', 'Index3', $overrideCycles1);
         $bclSample1->index2 = 'Index4';
 
         $bclSample1->adapterRead1 = 'Adapter3';
         $bclSample1->adapterRead2 = 'Adapter4';
 
-        $overrideCycles2 = new OverrideCycles('Y151', 'I8', 'I8', 'U10N12Y127');
+        $overrideCycles2 = new OverrideCycles($bclConvertDataSection, 'Y151', 'I8', 'I8', 'U10N12Y127');
         $bclSample2 = new BclSample(3, 'Sample3', 'Index5', $overrideCycles2);
         $bclSample2->index2 = 'Index6';
 
         $bclSample2->adapterRead1 = 'Adapter5';
         $bclSample2->adapterRead2 = 'Adapter6';
 
+        $overrideCycles3 = new OverrideCycles($bclConvertDataSection, 'Y101', 'I8', 'I8', 'Y101');
+        $bclSample3 = new BclSample(8, 'Sample4', 'Index5', $overrideCycles3);
+        $bclSample3->index2 = 'Index6';
+
+        $bclSample3->adapterRead1 = 'Adapter5';
+        $bclSample3->adapterRead2 = 'Adapter6';
+
+        $overrideCycles4 = new OverrideCycles($bclConvertDataSection, 'U5N2Y94', 'I8', 'I8', 'U5N2Y94');
+        $bclSample4 = new BclSample(6, 'Sample5', 'Index5', $overrideCycles4);
+        $bclSample4->index2 = 'Index6';
+
+        $bclSample4->adapterRead1 = 'Adapter5';
+        $bclSample4->adapterRead2 = 'Adapter6';
+
         $bclConvertDataSection->addSample($bclSample);
         $bclConvertDataSection->addSample($bclSample1);
         $bclConvertDataSection->addSample($bclSample2);
+        $bclConvertDataSection->addSample($bclSample3);
+        $bclConvertDataSection->addSample($bclSample4);
 
         $bclConvertSection = new BclConvertSection($bclConvertSettingsSection, $bclConvertDataSection);
 
@@ -60,8 +76,9 @@ final class NovaSeqXCloudSampleSheetTest extends TestCase
         $expected = '[Header]
 FileFormatVersion,2
 RunName,Run1
+IndexOrientation,Forward
 InstrumentPlatform,NovaSeqXSeries
-Custom_IndexOrientation,Orientation1
+Custom_TestKey,TestValue
 
 [Reads]
 Read1Cycles,151
@@ -76,9 +93,11 @@ TrimUMI,0
 
 [BCLConvert_Data]
 Lane,Sample_ID,Index,Index2,OverrideCycles,AdapterRead1,AdapterRead2
-1,Sample1,Index1,Index2,U7N1Y143;I8;I8;U7N1Y143,Adapter1,Adapter2
+1,Sample1,Index1,Index2,U7N1Y143;I8;N2I8;U7N1Y143,Adapter1,Adapter2
 2,Sample2,Index3,Index4,Y151;I8;U10;Y151,Adapter3,Adapter4
-3,Sample3,Index5,Index6,Y151;I8;I8;U10N12Y127,Adapter5,Adapter6
+3,Sample3,Index5,Index6,Y151;I8;N2I8;U10N12Y127N2,Adapter5,Adapter6
+8,Sample4,Index5,Index6,Y101N50;I8;N2I8;Y101N50,Adapter5,Adapter6
+6,Sample5,Index5,Index6,U5N2Y94N50;I8;N2I8;U5N2Y94N50,Adapter5,Adapter6
 ';
 
         self::assertSame($expected, $novaSeqXCloudSampleSheet->toString());

--- a/tests/Microplate/CoordinateSystemTest.php
+++ b/tests/Microplate/CoordinateSystemTest.php
@@ -6,12 +6,13 @@ use MLL\Utils\Microplate\CoordinateSystem;
 use MLL\Utils\Microplate\CoordinateSystem12Well;
 use MLL\Utils\Microplate\CoordinateSystem48Well;
 use MLL\Utils\Microplate\CoordinateSystem96Well;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CoordinateSystemTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('firstLast')]
     /** @dataProvider firstLast */
+    #[DataProvider('firstLast')]
     public function testFirstLast(CoordinateSystem $coordinateSystem, string $expectedFirst, string $expectedLast): void
     {
         $actualFirst = $coordinateSystem->first();

--- a/tests/Microplate/CoordinatesTest.php
+++ b/tests/Microplate/CoordinatesTest.php
@@ -6,12 +6,13 @@ use MLL\Utils\Microplate\Coordinates;
 use MLL\Utils\Microplate\CoordinateSystem12Well;
 use MLL\Utils\Microplate\CoordinateSystem96Well;
 use MLL\Utils\Microplate\Enums\FlowDirection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CoordinatesTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider96Well')]
     /** @dataProvider dataProvider96Well */
+    #[DataProvider('dataProvider96Well')]
     public function testCanConstructFromRowAndColumn(string $row, int $column, int $rowFlowPosition, int $columnFlowPosition): void
     {
         $coordinates96Well = new Coordinates($row, $column, new CoordinateSystem96Well());
@@ -19,8 +20,8 @@ final class CoordinatesTest extends TestCase
         self::assertSame($row . $column, $coordinates96Well->toString());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider96Well')]
     /** @dataProvider dataProvider96Well */
+    #[DataProvider('dataProvider96Well')]
     public function testCanConstructFromPosition(string $row, int $column, int $rowFlowPosition, int $columnFlowPosition): void
     {
         // test for Column-FlowDirection
@@ -42,8 +43,8 @@ final class CoordinatesTest extends TestCase
         self::assertSame($column, $coordinates->column);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider96Well')]
     /** @dataProvider dataProvider96Well */
+    #[DataProvider('dataProvider96Well')]
     public function testFromCoordinatesString(string $row, int $column, int $rowFlowPosition, int $columnFlowPosition): void
     {
         $coordinates = Coordinates::fromString($row . $column, new CoordinateSystem96Well());
@@ -51,8 +52,8 @@ final class CoordinatesTest extends TestCase
         self::assertSame($column, $coordinates->column);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProviderPadded96Well')]
     /** @dataProvider dataProviderPadded96Well */
+    #[DataProvider('dataProviderPadded96Well')]
     public function testFromPaddedCoordinatesString(string $paddedCoordinates, string $row, int $column): void
     {
         $coordinatesFromPadded = Coordinates::fromString($paddedCoordinates, new CoordinateSystem96Well());
@@ -92,8 +93,8 @@ final class CoordinatesTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider96Well')]
     /** @dataProvider dataProvider96Well */
+    #[DataProvider('dataProvider96Well')]
     public function testPosition96Well(string $row, int $column, int $rowFlowPosition, int $columnFlowPosition): void
     {
         $coordinates = new Coordinates($row, $column, new CoordinateSystem96Well());
@@ -689,8 +690,8 @@ final class CoordinatesTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider12Well')]
     /** @dataProvider dataProvider12Well */
+    #[DataProvider('dataProvider12Well')]
     public function testPosition12Well(string $row, int $column, int $rowFlowPosition, int $columnFlowPosition): void
     {
         $coordinates = new Coordinates($row, $column, new CoordinateSystem12Well());
@@ -777,8 +778,8 @@ final class CoordinatesTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('invalidRowsOrColumns')]
     /** @dataProvider invalidRowsOrColumns */
+    #[DataProvider('invalidRowsOrColumns')]
     public function testThrowsOnInvalidRowsOrColumns(string $row, int $column): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -796,8 +797,8 @@ final class CoordinatesTest extends TestCase
         yield ['rolf', 2];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('invalidPositions')]
     /** @dataProvider invalidPositions */
+    #[DataProvider('invalidPositions')]
     public function testThrowsOnInvalidPositions(int $position): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -813,8 +814,8 @@ final class CoordinatesTest extends TestCase
         yield [10000];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('invalidCoordinates')]
     /** @dataProvider invalidCoordinates */
+    #[DataProvider('invalidCoordinates')]
     public function testThrowsOnInvalidCoordinates(string $coordinatesString): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Microplate/MicroplateSet/MicroplateSetABCDTest.php
+++ b/tests/Microplate/MicroplateSet/MicroplateSetABCDTest.php
@@ -6,6 +6,7 @@ use MLL\Utils\Microplate\CoordinateSystem12Well;
 use MLL\Utils\Microplate\CoordinateSystem96Well;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use MLL\Utils\Microplate\MicroplateSet\MicroplateSetABCD;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MicroplateSetABCDTest extends TestCase
@@ -46,8 +47,8 @@ final class MicroplateSetABCDTest extends TestCase
         $microplateSet->locationFromPosition($setPositionLowerThanMin, FlowDirection::COLUMN());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider12Well')]
     /** @dataProvider dataProvider12Well */
+    #[DataProvider('dataProvider12Well')]
     public function testSetLocationFromSetPositionFor12Wells(int $position, string $coordinatesString, string $plateID): void
     {
         $microplateSet = new MicroplateSetABCD(new CoordinateSystem12Well());
@@ -92,8 +93,8 @@ final class MicroplateSetABCDTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider96Well')]
     /** @dataProvider dataProvider96Well */
+    #[DataProvider('dataProvider96Well')]
     public function testSetLocationFromSetPositionFor96Wells(int $position, string $coordinatesString, string $plateID): void
     {
         $microplateSet = new MicroplateSetABCD(new CoordinateSystem96Well());

--- a/tests/Microplate/MicroplateSet/MicroplateSetABTest.php
+++ b/tests/Microplate/MicroplateSet/MicroplateSetABTest.php
@@ -6,6 +6,7 @@ use MLL\Utils\Microplate\CoordinateSystem12Well;
 use MLL\Utils\Microplate\CoordinateSystem96Well;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use MLL\Utils\Microplate\MicroplateSet\MicroplateSetAB;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MicroplateSetABTest extends TestCase
@@ -46,8 +47,8 @@ final class MicroplateSetABTest extends TestCase
         $microplateSet->locationFromPosition($setPositionLowerThanMin, FlowDirection::COLUMN());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider12Well')]
     /** @dataProvider dataProvider12Well */
+    #[DataProvider('dataProvider12Well')]
     public function testSetLocationFromSetPositionFor12Wells(int $position, string $coordinatesString, string $plateID): void
     {
         $microplateSet = new MicroplateSetAB(new CoordinateSystem12Well());
@@ -92,8 +93,8 @@ final class MicroplateSetABTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataProvider96Well')]
     /** @dataProvider dataProvider96Well */
+    #[DataProvider('dataProvider96Well')]
     public function testSetLocationFromSetPositionFor96Wells(int $position, string $coordinatesString, string $plateID): void
     {
         $microplateSet = new MicroplateSetAB(new CoordinateSystem96Well());

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -3,6 +3,7 @@
 namespace MLL\Utils\Tests;
 
 use MLL\Utils\Number;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class NumberTest extends TestCase
@@ -15,7 +16,7 @@ final class NumberTest extends TestCase
      * @param float|int $current
      * @param float|int $expected
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('clampProvider')]
+    #[DataProvider('clampProvider')]
     public function testClamp($min, $max, $current, $expected): void
     {
         self::assertSame($expected, Number::clamp($min, $max, $current));

--- a/tests/StringUtilTest.php
+++ b/tests/StringUtilTest.php
@@ -4,6 +4,7 @@ namespace MLL\Utils\Tests;
 
 use Illuminate\Support\Collection;
 use MLL\Utils\StringUtil;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class StringUtilTest extends TestCase
@@ -13,7 +14,7 @@ final class StringUtilTest extends TestCase
      *
      * @param iterable<string|null> $parts
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('joinNonEmpty')]
+    #[DataProvider('joinNonEmpty')]
     public function testJoinNonEmpty(string $expectedJoined, string $glue, iterable $parts): void
     {
         self::assertSame(
@@ -30,8 +31,8 @@ final class StringUtilTest extends TestCase
         yield ['a,b', ',', new Collection(['a', null, '', 'b'])];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('shortenFirstname')]
     /** @dataProvider shortenFirstname */
+    #[DataProvider('shortenFirstname')]
     public function testShortenFirstname(string $expectedShortened, string $input): void
     {
         self::assertSame(
@@ -55,7 +56,7 @@ final class StringUtilTest extends TestCase
      *
      * @param array<int, string> $expectedLines
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('splitLines')]
+    #[DataProvider('splitLines')]
     public function testSplitLines(array $expectedLines, string $input): void
     {
         self::assertSame($expectedLines, StringUtil::splitLines($input));


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

- All OverrideCycle total counts on DataSection must grow to the Reads-Sections maximum value by adding the N-tag
