### PR TITLE
Offer unified coordinate system classes, deprecate naming by count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ See [GitHub releases](https://github.com/mll-lab/php-utils/releases).
 
 ## Unreleased
 
+## v5.2.0
+
+### Added
+
+- Add coordinate systems `CoordinateSystem4x3`, `CoordinateSystem8x6` and `CoordinateSystem12x8`
+
+### Changed
+
+- Deprecate coordinate systems `CoordinateSystem12Well`, `CoordinateSytem48Well` and `CoordinateSystem96Well`
+
 ## v5.1.0
 
 ### Added

--- a/src/FluidXPlate/FluidXPlate.php
+++ b/src/FluidXPlate/FluidXPlate.php
@@ -4,7 +4,7 @@ namespace MLL\Utils\FluidXPlate;
 
 use Illuminate\Support\Collection;
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use MLL\Utils\Microplate\Microplate;
 
@@ -15,7 +15,7 @@ class FluidXPlate
 
     public string $rackID;
 
-    /** @var Microplate<string, CoordinateSystem96Well> */
+    /** @var Microplate<string, CoordinateSystem12x8> */
     private Microplate $microplate;
 
     public function __construct(string $rackID)
@@ -27,12 +27,12 @@ class FluidXPlate
         $this->microplate = new Microplate(self::coordinateSystem());
     }
 
-    public static function coordinateSystem(): CoordinateSystem96Well
+    public static function coordinateSystem(): CoordinateSystem12x8
     {
-        return new CoordinateSystem96Well();
+        return new CoordinateSystem12x8();
     }
 
-    /** @param Coordinates<CoordinateSystem96Well> $coordinates */
+    /** @param Coordinates<CoordinateSystem12x8> $coordinates */
     public function addWell(Coordinates $coordinates, string $barcode): void
     {
         if (\Safe\preg_match(self::FLUIDX_BARCODE_REGEX, $barcode) === 0) {
@@ -42,7 +42,7 @@ class FluidXPlate
         $this->microplate->addWell($coordinates, $barcode);
     }
 
-    /** @return Coordinates<CoordinateSystem96Well> */
+    /** @return Coordinates<CoordinateSystem12x8> */
     public function addToNextFreeWell(string $content, FlowDirection $flowDirection): Coordinates
     {
         return $this->microplate->addToNextFreeWell($content, $flowDirection);

--- a/src/FluidXPlate/FluidXScanner.php
+++ b/src/FluidXPlate/FluidXScanner.php
@@ -87,8 +87,9 @@ class FluidXScanner
         }
 
         $plate = new FluidXPlate($id);
+        $coordinateSystem = FluidXPlate::coordinateSystem();
         foreach ($barcodes as $coordinates => $barcode) {
-            $plate->addWell(Coordinates::fromString($coordinates, new CoordinateSystem12x8()), $barcode);
+            $plate->addWell(Coordinates::fromString($coordinates, $coordinateSystem), $barcode);
         }
 
         return $plate;

--- a/src/FluidXPlate/FluidXScanner.php
+++ b/src/FluidXPlate/FluidXScanner.php
@@ -4,7 +4,7 @@ namespace MLL\Utils\FluidXPlate;
 
 use Illuminate\Support\Str;
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\StringUtil;
 
 /** Communicates with a FluidX scanner device and fetches results from it. */
@@ -88,7 +88,7 @@ class FluidXScanner
 
         $plate = new FluidXPlate($id);
         foreach ($barcodes as $coordinates => $barcode) {
-            $plate->addWell(Coordinates::fromString($coordinates, new CoordinateSystem96Well()), $barcode);
+            $plate->addWell(Coordinates::fromString($coordinates, new CoordinateSystem12x8()), $barcode);
         }
 
         return $plate;

--- a/src/FluidXPlate/FluidXScanner.php
+++ b/src/FluidXPlate/FluidXScanner.php
@@ -4,7 +4,6 @@ namespace MLL\Utils\FluidXPlate;
 
 use Illuminate\Support\Str;
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\StringUtil;
 
 /** Communicates with a FluidX scanner device and fetches results from it. */

--- a/src/Microplate/CoordinateSystem.php
+++ b/src/Microplate/CoordinateSystem.php
@@ -4,7 +4,10 @@ namespace MLL\Utils\Microplate;
 
 use Illuminate\Support\Arr;
 
-/** Children should be called `CoordinateSystemXxY`, where X is the number of columns and Y is the number of rows. */
+/**
+ * Children should be called `CoordinateSystemXxY`, where X is the number of columns and Y is the number of rows.
+ * Naming them by the number of positions is insufficient, e.g. it does not allow distinguishing between 3x4 and 4x3.
+ */
 abstract class CoordinateSystem
 {
     /** @return list<string> */

--- a/src/Microplate/CoordinateSystem.php
+++ b/src/Microplate/CoordinateSystem.php
@@ -4,6 +4,7 @@ namespace MLL\Utils\Microplate;
 
 use Illuminate\Support\Arr;
 
+/** Children should be called `CoordinateSystemXxY`, where X is the number of columns and Y is the number of rows. */
 abstract class CoordinateSystem
 {
     /** @return list<string> */

--- a/src/Microplate/CoordinateSystem12Well.php
+++ b/src/Microplate/CoordinateSystem12Well.php
@@ -2,18 +2,5 @@
 
 namespace MLL\Utils\Microplate;
 
-class CoordinateSystem12Well extends CoordinateSystem
-{
-    /** Duplicates @see CoordinateSystem::positionsCount() for static contexts. */
-    public const POSITIONS_COUNT = 12;
-
-    public function rows(): array
-    {
-        return range('A', 'C');
-    }
-
-    public function columns(): array
-    {
-        return range(1, 4);
-    }
-}
+/** @deprecated use CoordinateSystem4x3 */
+class CoordinateSystem12Well extends CoordinateSystem4x3 {}

--- a/src/Microplate/CoordinateSystem12x8.php
+++ b/src/Microplate/CoordinateSystem12x8.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Microplate;
+
+class CoordinateSystem12x8 extends CoordinateSystem
+{
+    /** Duplicates @see CoordinateSystem::positionsCount() for static contexts. */
+    public const POSITIONS_COUNT = 96;
+
+    public function rows(): array
+    {
+        return range('A', 'H');
+    }
+
+    public function columns(): array
+    {
+        return range(1, 12);
+    }
+}

--- a/src/Microplate/CoordinateSystem48Well.php
+++ b/src/Microplate/CoordinateSystem48Well.php
@@ -2,18 +2,5 @@
 
 namespace MLL\Utils\Microplate;
 
-class CoordinateSystem48Well extends CoordinateSystem
-{
-    /** Duplicates @see CoordinateSystem::positionsCount() for static contexts. */
-    public const POSITIONS_COUNT = 48;
-
-    public function rows(): array
-    {
-        return range('A', 'F');
-    }
-
-    public function columns(): array
-    {
-        return range(1, 8);
-    }
-}
+/** @deprecated use CoordinateSystem8x6 */
+class CoordinateSystem48Well extends CoordinateSystem8x6 {}

--- a/src/Microplate/CoordinateSystem4x3.php
+++ b/src/Microplate/CoordinateSystem4x3.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Microplate;
+
+class CoordinateSystem4x3 extends CoordinateSystem
+{
+    /** Duplicates @see CoordinateSystem::positionsCount() for static contexts. */
+    public const POSITIONS_COUNT = 12;
+
+    public function rows(): array
+    {
+        return range('A', 'C');
+    }
+
+    public function columns(): array
+    {
+        return range(1, 4);
+    }
+}

--- a/src/Microplate/CoordinateSystem8x6.php
+++ b/src/Microplate/CoordinateSystem8x6.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Microplate;
+
+class CoordinateSystem8x6 extends CoordinateSystem
+{
+    /** Duplicates @see CoordinateSystem::positionsCount() for static contexts. */
+    public const POSITIONS_COUNT = 48;
+
+    public function rows(): array
+    {
+        return range('A', 'F');
+    }
+
+    public function columns(): array
+    {
+        return range(1, 8);
+    }
+}

--- a/src/Microplate/CoordinateSystem96Well.php
+++ b/src/Microplate/CoordinateSystem96Well.php
@@ -2,18 +2,5 @@
 
 namespace MLL\Utils\Microplate;
 
-class CoordinateSystem96Well extends CoordinateSystem
-{
-    /** Duplicates @see CoordinateSystem::positionsCount() for static contexts. */
-    public const POSITIONS_COUNT = 96;
-
-    public function rows(): array
-    {
-        return range('A', 'H');
-    }
-
-    public function columns(): array
-    {
-        return range(1, 12);
-    }
-}
+/** @deprecated use CoordinateSystem12x8 */
+class CoordinateSystem96Well extends CoordinateSystem12x8 {}

--- a/src/QxManager/FilledWell.php
+++ b/src/QxManager/FilledWell.php
@@ -3,7 +3,7 @@
 namespace MLL\Utils\QxManager;
 
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 
 class FilledWell
 {
@@ -17,7 +17,7 @@ class FilledWell
         $this->hexRow = $hexRow;
     }
 
-    /** @param Coordinates<CoordinateSystem96Well> $coordinates */
+    /** @param Coordinates<CoordinateSystem12x8> $coordinates */
     public function toString(Coordinates $coordinates): string
     {
         return $coordinates->toPaddedString() . QxManagerSampleSheet::DELIMITER . $this->famRow->toString() . QxManagerSampleSheet::EOL

--- a/src/QxManager/QxManagerSampleSheet.php
+++ b/src/QxManager/QxManagerSampleSheet.php
@@ -4,7 +4,7 @@ namespace MLL\Utils\QxManager;
 
 use Carbon\CarbonInterface;
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use MLL\Utils\Microplate\Microplate;
 use MLL\Utils\StringUtil;
@@ -14,33 +14,32 @@ class QxManagerSampleSheet
     public const EOL = "\r\n";
     public const DELIMITER = ',';
 
-    /** @param Microplate<FilledWell, CoordinateSystem96Well> $microplate */
+    /** @param Microplate<FilledWell, CoordinateSystem12x8> $microplate */
     public function toCsvString(Microplate $microplate, CarbonInterface $createdDate): string
     {
-        $header = StringUtil::normalizeLineEndings(
-            <<<CSV
+        $header = StringUtil::normalizeLineEndings(<<<CSV
 ddplate - DO NOT MODIFY THIS LINE,Version=1,ApplicationName=QX Manager Standard Edition,ApplicationVersion=2.0.0.665,ApplicationEdition=ResearchEmbedded,User=\QX User,CreatedDate={$createdDate->format('n/j/Y g:i:s A')},
 
 PlateSize=GCR96
 PlateNotes=
 Well,Perform Droplet Reading,ExperimentType,Sample description 1,Sample description 2,Sample description 3,Sample description 4,SampleType,SupermixName,AssayType,TargetName,TargetType,Signal Ch1,Signal Ch2,Reference Copies,Well Notes,Plot?,RdqConversionFactor
 
-CSV
-        );
+CSV);
 
-        return $header . $microplate->sortedWells(FlowDirection::ROW())
-            ->map(
-                /** @param FilledWell|null $well */
-                function ($well, string $coordinateString) use ($microplate): string {
-                    $coordinates = Coordinates::fromString($coordinateString, $microplate->coordinateSystem);
+        $body = $microplate->sortedWells(FlowDirection::ROW())
+            ->map(function ($well, string $coordinateString) use ($microplate): string {
+                $coordinates = Coordinates::fromString($coordinateString, $microplate->coordinateSystem);
 
-                    if ($well instanceof FilledWell) {
-                        return $well->toString($coordinates);
-                    }
-
-                    return $coordinates->toPaddedString() . QxManagerSampleSheet::DELIMITER . (new EmptyRow())->toString();
+                if ($well instanceof FilledWell) {
+                    return $well->toString($coordinates);
                 }
-            )
-            ->join(self::EOL) . self::EOL;
+
+                return $coordinates->toPaddedString()
+                    . QxManagerSampleSheet::DELIMITER
+                    . (new EmptyRow())->toString();
+            })
+            ->join(self::EOL);
+
+        return $header . $body . self::EOL;
     }
 }

--- a/src/Tecan/Rack/DestLC.php
+++ b/src/Tecan/Rack/DestLC.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tecan\Rack;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 
 /**
  * @template TContent
@@ -13,7 +13,7 @@ class DestLC extends BaseRack
 {
     public function __construct()
     {
-        parent::__construct(new CoordinateSystem96Well());
+        parent::__construct(new CoordinateSystem12x8());
     }
 
     public function type(): string

--- a/src/Tecan/Rack/DestPCR.php
+++ b/src/Tecan/Rack/DestPCR.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tecan\Rack;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 
 /**
  * @template TContent
@@ -13,7 +13,7 @@ class DestPCR extends BaseRack
 {
     public function __construct()
     {
-        parent::__construct(new CoordinateSystem96Well());
+        parent::__construct(new CoordinateSystem12x8());
     }
 
     public function type(): string

--- a/src/Tecan/Rack/DestTaqMan.php
+++ b/src/Tecan/Rack/DestTaqMan.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tecan\Rack;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 
 /**
  * @template TContent
@@ -13,7 +13,7 @@ class DestTaqMan extends BaseRack
 {
     public function __construct()
     {
-        parent::__construct(new CoordinateSystem96Well());
+        parent::__construct(new CoordinateSystem12x8());
     }
 
     public function type(): string

--- a/src/Tecan/Rack/FluidXRack.php
+++ b/src/Tecan/Rack/FluidXRack.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tecan\Rack;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 
 /**
  * @template TContent
@@ -13,7 +13,7 @@ class FluidXRack extends BaseRack implements ScannedRack
 {
     public function __construct()
     {
-        parent::__construct(new CoordinateSystem96Well());
+        parent::__construct(new CoordinateSystem12x8());
     }
 
     public function type(): string

--- a/src/Tecan/Rack/MPCDNA.php
+++ b/src/Tecan/Rack/MPCDNA.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tecan\Rack;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 
 /**
  * @template TContent
@@ -13,7 +13,7 @@ class MPCDNA extends BaseRack
 {
     public function __construct()
     {
-        parent::__construct(new CoordinateSystem96Well());
+        parent::__construct(new CoordinateSystem12x8());
     }
 
     public function type(): string

--- a/src/Tecan/Rack/MPSample.php
+++ b/src/Tecan/Rack/MPSample.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tecan\Rack;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 
 /**
  * @template TContent
@@ -13,7 +13,7 @@ class MPSample extends BaseRack
 {
     public function __construct()
     {
-        parent::__construct(new CoordinateSystem96Well());
+        parent::__construct(new CoordinateSystem12x8());
     }
 
     public function type(): string

--- a/tests/FluidXPlate/FluidXPlateTest.php
+++ b/tests/FluidXPlate/FluidXPlateTest.php
@@ -6,7 +6,7 @@ use MLL\Utils\FluidXPlate\FluidXPlate;
 use MLL\Utils\FluidXPlate\InvalidRackIDException;
 use MLL\Utils\FluidXPlate\InvalidTubeBarcodeException;
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use PHPUnit\Framework\TestCase;
 
@@ -41,7 +41,7 @@ final class FluidXPlateTest extends TestCase
         $barcode = 'testWrongBarcode';
         $rackID = 'AB12345678';
         $fluidXPlate = new FluidXPlate($rackID);
-        $coordinates = Coordinates::fromString('A1', new CoordinateSystem96Well());
+        $coordinates = Coordinates::fromString('A1', new CoordinateSystem12x8());
 
         $this->expectExceptionObject(new InvalidTubeBarcodeException($barcode));
         $fluidXPlate->addWell($coordinates, $barcode);
@@ -51,7 +51,7 @@ final class FluidXPlateTest extends TestCase
     {
         $rackID = 'AB12345678';
         $fluidXPlate = new FluidXPlate($rackID);
-        $coordinates = Coordinates::fromString('A1', new CoordinateSystem96Well());
+        $coordinates = Coordinates::fromString('A1', new CoordinateSystem12x8());
 
         $this->expectException(\TypeError::class);
         // @phpstan-ignore-next-line intentionally wrong
@@ -62,7 +62,7 @@ final class FluidXPlateTest extends TestCase
     {
         $rackID = 'AB12345678';
         $fluidXPlate = new FluidXPlate($rackID);
-        $expectedCoordinates = Coordinates::fromString('A1', new CoordinateSystem96Well());
+        $expectedCoordinates = Coordinates::fromString('A1', new CoordinateSystem12x8());
         $addToNextFreeWell = $fluidXPlate->addToNextFreeWell('test', FlowDirection::COLUMN());
         self::assertEquals($expectedCoordinates, $addToNextFreeWell);
     }

--- a/tests/Microplate/CoordinateSystemTest.php
+++ b/tests/Microplate/CoordinateSystemTest.php
@@ -3,10 +3,12 @@
 namespace MLL\Utils\Tests\Microplate;
 
 use MLL\Utils\Microplate\CoordinateSystem;
-use MLL\Utils\Microplate\CoordinateSystem12Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
+use MLL\Utils\Microplate\CoordinateSystem1x1;
 use MLL\Utils\Microplate\CoordinateSystem2x16;
-use MLL\Utils\Microplate\CoordinateSystem48Well;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem4x3;
+use MLL\Utils\Microplate\CoordinateSystem6x4;
+use MLL\Utils\Microplate\CoordinateSystem8x6;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -28,17 +30,21 @@ final class CoordinateSystemTest extends TestCase
     /** @return iterable<array{CoordinateSystem, string, string}> */
     public static function firstLast(): iterable
     {
-        yield [new CoordinateSystem12Well(), 'A1', 'C4'];
-        yield [new CoordinateSystem48Well(), 'A1', 'F8'];
-        yield [new CoordinateSystem96Well(), 'A1', 'H12'];
-        yield [new CoordinateSystem2x16(), 'A1', 'P2'];
+        yield '1x1' => [new CoordinateSystem1x1(), 'A1', 'A1'];
+        yield '2x16' => [new CoordinateSystem2x16(), 'A1', 'P2'];
+        yield '4x3' => [new CoordinateSystem4x3(), 'A1', 'C4'];
+        yield '6x4' => [new CoordinateSystem6x4(), 'A1', 'D6'];
+        yield '8x6' => [new CoordinateSystem8x6(), 'A1', 'F8'];
+        yield '12x8' => [new CoordinateSystem12x8(), 'A1', 'H12'];
     }
 
     public function testPositionsCount(): void
     {
-        self::assertSame(CoordinateSystem12Well::POSITIONS_COUNT, (new CoordinateSystem12Well())->positionsCount());
-        self::assertSame(CoordinateSystem48Well::POSITIONS_COUNT, (new CoordinateSystem48Well())->positionsCount());
-        self::assertSame(CoordinateSystem96Well::POSITIONS_COUNT, (new CoordinateSystem96Well())->positionsCount());
+        self::assertSame(CoordinateSystem1x1::POSITIONS_COUNT, (new CoordinateSystem1x1())->positionsCount());
         self::assertSame(CoordinateSystem2x16::POSITIONS_COUNT, (new CoordinateSystem2x16())->positionsCount());
+        self::assertSame(CoordinateSystem4x3::POSITIONS_COUNT, (new CoordinateSystem4x3())->positionsCount());
+        self::assertSame(CoordinateSystem6x4::POSITIONS_COUNT, (new CoordinateSystem6x4())->positionsCount());
+        self::assertSame(CoordinateSystem8x6::POSITIONS_COUNT, (new CoordinateSystem8x6())->positionsCount());
+        self::assertSame(CoordinateSystem12x8::POSITIONS_COUNT, (new CoordinateSystem12x8())->positionsCount());
     }
 }

--- a/tests/Microplate/CoordinatesTest.php
+++ b/tests/Microplate/CoordinatesTest.php
@@ -4,10 +4,10 @@ namespace MLL\Utils\Tests\Microplate;
 
 use MLL\Utils\Microplate\Coordinates;
 use MLL\Utils\Microplate\CoordinateSystem;
-use MLL\Utils\Microplate\CoordinateSystem12Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\CoordinateSystem2x16;
-use MLL\Utils\Microplate\CoordinateSystem48Well;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem4x3;
+use MLL\Utils\Microplate\CoordinateSystem8x6;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +25,7 @@ final class CoordinatesTest extends TestCase
     /**
      * @dataProvider dataProviderWells
      *
-     * @param WellData[] $wells
+     * @param array<WellData> $wells
      */
     #[DataProvider('dataProviderWells')]
     public function testCanConstructFromRowAndColumn(CoordinateSystem $coordinateSystem, array $wells): void
@@ -39,7 +39,7 @@ final class CoordinatesTest extends TestCase
     /**
      * @dataProvider dataProviderWells
      *
-     * @param WellData[] $wells
+     * @param array<WellData> $wells
      */
     #[DataProvider('dataProviderWells')]
     public function testCanConstructFromPosition(CoordinateSystem $coordinateSystem, array $wells): void
@@ -68,7 +68,7 @@ final class CoordinatesTest extends TestCase
     /**
      * @dataProvider dataProviderWells
      *
-     * @param WellData[] $wells
+     * @param array<WellData> $wells
      */
     #[DataProvider('dataProviderWells')]
     public function testFromCoordinatesString(CoordinateSystem $coordinateSystem, array $wells): void
@@ -103,7 +103,7 @@ final class CoordinatesTest extends TestCase
     /**
      * @dataProvider dataProviderWells
      *
-     * @param WellData[] $wells
+     * @param array<WellData> $wells
      */
     #[DataProvider('dataProviderWells')]
     public function testPositionWells(CoordinateSystem $coordinateSystem, array $wells): void
@@ -116,47 +116,65 @@ final class CoordinatesTest extends TestCase
     }
 
     /**
-     * @return array<string, array{CoordinateSystem, array<array{
-     *  paddedCoordinates: string,
-     *  row: string,
-     *  column: int
-     *  }>}> $paddedWells
-     * */
+     * @return array<
+     *   string,
+     *   array{
+     *     CoordinateSystem,
+     *     array<
+     *       array{
+     *         paddedCoordinates: string,
+     *         row: string,
+     *         column: int,
+     *       }
+     *     >
+     *   }
+     * > $paddedWells
+     */
     public static function dataProviderPaddedWells(): array
     {
         return [
-            '12Wells' => [new CoordinateSystem12Well(), [
-                ['paddedCoordinates' => 'A1', 'row' => 'A', 'column' => 1],
-                ['paddedCoordinates' => 'C4', 'row' => 'C', 'column' => 4],
-            ], ],
-            '48Wells' => [new CoordinateSystem48Well(), [
-                ['paddedCoordinates' => 'A1', 'row' => 'A', 'column' => 1],
-                ['paddedCoordinates' => 'F8', 'row' => 'F', 'column' => 8],
-            ], ],
-            '96Wells' => [new CoordinateSystem96Well(), [
-                ['paddedCoordinates' => 'A01', 'row' => 'A', 'column' => 1],
-                ['paddedCoordinates' => 'C05', 'row' => 'C', 'column' => 5],
-                ['paddedCoordinates' => 'H12', 'row' => 'H', 'column' => 12],
-                ['paddedCoordinates' => 'D10', 'row' => 'D', 'column' => 10],
-            ], ],
-            '2x16Wells' => [new CoordinateSystem2x16(), [
-                ['paddedCoordinates' => 'A1', 'row' => 'A', 'column' => 1],
-                ['paddedCoordinates' => 'B2', 'row' => 'B', 'column' => 2],
-                ['paddedCoordinates' => 'M1', 'row' => 'M', 'column' => 1],
-                ['paddedCoordinates' => 'K2', 'row' => 'K', 'column' => 2],
-            ], ],
+            '12Wells' => [
+                new CoordinateSystem4x3(),
+                [
+                    ['paddedCoordinates' => 'A1', 'row' => 'A', 'column' => 1],
+                    ['paddedCoordinates' => 'C4', 'row' => 'C', 'column' => 4],
+                ],
+            ],
+            '48Wells' => [
+                new CoordinateSystem8x6(),
+                [
+                    ['paddedCoordinates' => 'A1', 'row' => 'A', 'column' => 1],
+                    ['paddedCoordinates' => 'F8', 'row' => 'F', 'column' => 8],
+                ],
+            ],
+            '96Wells' => [
+                new CoordinateSystem12x8(),
+                [
+                    ['paddedCoordinates' => 'A01', 'row' => 'A', 'column' => 1],
+                    ['paddedCoordinates' => 'C05', 'row' => 'C', 'column' => 5],
+                    ['paddedCoordinates' => 'H12', 'row' => 'H', 'column' => 12],
+                    ['paddedCoordinates' => 'D10', 'row' => 'D', 'column' => 10],
+                ],
+            ],
+            '2x16Wells' => [
+                new CoordinateSystem2x16(),
+                [
+                    ['paddedCoordinates' => 'A1', 'row' => 'A', 'column' => 1],
+                    ['paddedCoordinates' => 'B2', 'row' => 'B', 'column' => 2],
+                    ['paddedCoordinates' => 'M1', 'row' => 'M', 'column' => 1],
+                    ['paddedCoordinates' => 'K2', 'row' => 'K', 'column' => 2],
+                ],
+            ],
         ];
     }
 
-    /** @return array<string, array{CoordinateSystem, WellData[]}> */
-    public static function dataProviderWells(): array
+    /** @return iterable<array{CoordinateSystem, array<WellData>}> */
+    public static function dataProviderWells(): iterable
     {
-        return [
-            '12Wells' => [new CoordinateSystem12Well(), self::data12Wells()],
-            '48ells' => [new CoordinateSystem48Well(), self::data48Wells()],
-            '96Wells' => [new CoordinateSystem96Well(), self::data96Wells()],
-            '2x16Wells' => [new CoordinateSystem2x16(), self::data2x16Wells()],
-        ];
+        yield '2x16' => [new CoordinateSystem2x16(), self::data2x16()];
+        yield '4x3' => [new CoordinateSystem4x3(), self::data4x3()];
+        yield '8x6' => [new CoordinateSystem8x6(), self::data8x6()];
+        yield '12x8' => [new CoordinateSystem12x8(), self::data12x8()];
     }
 
     /**
@@ -173,15 +191,13 @@ final class CoordinatesTest extends TestCase
         }
     }
 
-    /** @return array<string, array{CoordinateSystem, array<array{string, int}>}> */
+    /** @return iterable<array{CoordinateSystem, array<array{string, int}>}> */
     public static function invalidRowsOrColumns(): iterable
     {
-        return [
-            '12Wells' => [new CoordinateSystem12Well(), [['X', 2], ['B', 0], ['B', 4], ['B', -1], ['B', 1000], ['rolf', 2], ['D', 1]]],
-            '48Wells' => [new CoordinateSystem48Well(), [['X', 2], ['B', 0], ['B', 4], ['B', -1], ['B', 1000], ['rolf', 2], ['G', 1]]],
-            '96Wells' => [new CoordinateSystem96Well(), [['X', 2], ['B', 0], ['B', 13], ['B', -1], ['B', 1000], ['rolf', 2]]],
-            '2x16Wells' => [new CoordinateSystem2x16(), [['X', 2], ['B', 0], ['B', 3], ['B', -1], ['B', 1000], ['rolf', 2]]],
-        ];
+        yield '2x16' => [new CoordinateSystem2x16(), [['X', 2], ['B', 0], ['B', 3], ['B', -1], ['B', 1000], ['rolf', 2]]];
+        yield '4x3' => [new CoordinateSystem4x3(), [['X', 2], ['B', 0], ['B', 4], ['B', -1], ['B', 1000], ['rolf', 2], ['D', 1]]];
+        yield '8x6' => [new CoordinateSystem8x6(), [['X', 2], ['B', 0], ['B', 4], ['B', -1], ['B', 1000], ['rolf', 2], ['G', 1]]];
+        yield '12x8' => [new CoordinateSystem12x8(), [['X', 2], ['B', 0], ['B', 13], ['B', -1], ['B', 1000], ['rolf', 2]]];
     }
 
     /**
@@ -194,19 +210,17 @@ final class CoordinatesTest extends TestCase
     {
         foreach ($positions as $position) {
             $this->expectException(\InvalidArgumentException::class);
-            Coordinates::fromPosition($position, FlowDirection::COLUMN(), new CoordinateSystem96Well());
+            Coordinates::fromPosition($position, FlowDirection::COLUMN(), new CoordinateSystem12x8());
         }
     }
 
-    /** @return array<string, array{CoordinateSystem, array<int>}> */
+    /** @return iterable<array{CoordinateSystem, array<int>}> */
     public static function invalidPositions(): iterable
     {
-        return [
-            '12Wells' => [new CoordinateSystem12Well(), [0, -1, 13, 10000]],
-            '48Wells' => [new CoordinateSystem48Well(), [0, -1, 49, 10000]],
-            '96Wells' => [new CoordinateSystem96Well(), [0, -1, 97, 10000]],
-            '2x16Wells' => [new CoordinateSystem2x16(), [0, -1, 33, 10000]],
-        ];
+        yield '2x16' => [new CoordinateSystem2x16(), [0, -1, 33, 10000]];
+        yield '4x3' => [new CoordinateSystem4x3(), [0, -1, 13, 10000]];
+        yield '8x6' => [new CoordinateSystem8x6(), [0, -1, 49, 10000]];
+        yield '12x8' => [new CoordinateSystem12x8(), [0, -1, 97, 10000]];
     }
 
     /**
@@ -223,19 +237,16 @@ final class CoordinatesTest extends TestCase
         }
     }
 
-    /** @return array<string, array{CoordinateSystem, array<string>}> */
-    public static function invalidCoordinates(): array
+    /** @return iterable<array{CoordinateSystem, array<string>}> */
+    public static function invalidCoordinates(): iterable
     {
-        return [
-            '12Wells' => [new CoordinateSystem2x16(), ['A0', 'A01', 'D3', 'C5', 'rolf', 'a1']],
-            '48Wells' => [new CoordinateSystem48Well(), ['A0', 'A01', 'G3', 'C9', 'rolf', 'a1']],
-            '96Wells' => [new CoordinateSystem96Well(), ['A0', 'A001', 'X3', 'rolf', 'a1']],
-            '2x16Wells' => [new CoordinateSystem2x16(), ['A0', 'A01', 'X3', 'rolf', 'a1']],
-        ];
+        yield '2x16' => [new CoordinateSystem2x16(), ['A0', 'A01', 'D3', 'C5', 'X3', 'rolf', 'a1']];
+        yield '8x6' => [new CoordinateSystem8x6(), ['A0', 'A01', 'G3', 'C9', 'rolf', 'a1']];
+        yield '12x8' => [new CoordinateSystem12x8(), ['A0', 'A001', 'X3', 'rolf', 'a1']];
     }
 
     /** @return array<WellData> */
-    public static function data2x16Wells(): array
+    public static function data2x16(): array
     {
         return [
             ['row' => 'A', 'column' => 1, 'rowFlowPosition' => 1, 'columnFlowPosition' => 1],
@@ -274,7 +285,7 @@ final class CoordinatesTest extends TestCase
     }
 
     /** @return array<WellData> */
-    public static function data12Wells(): array
+    public static function data4x3(): array
     {
         return [
             ['row' => 'A', 'column' => 1, 'rowFlowPosition' => 1, 'columnFlowPosition' => 1],
@@ -293,7 +304,7 @@ final class CoordinatesTest extends TestCase
     }
 
     /** @return array<WellData> */
-    public static function data48Wells(): array
+    public static function data8x6(): array
     {
         return [
             ['row' => 'A', 'column' => 1, 'rowFlowPosition' => 1, 'columnFlowPosition' => 1],
@@ -348,7 +359,7 @@ final class CoordinatesTest extends TestCase
     }
 
     /** @return array<WellData> */
-    public static function data96Wells(): array
+    public static function data12x8(): array
     {
         return [
             ['row' => 'A', 'column' => 1, 'rowFlowPosition' => 1, 'columnFlowPosition' => 1],

--- a/tests/Microplate/MicroplateSet/MicroplateSetABCDETest.php
+++ b/tests/Microplate/MicroplateSet/MicroplateSetABCDETest.php
@@ -2,26 +2,26 @@
 
 namespace MLL\Utils\Tests\Microplate\MicroplateSet;
 
-use MLL\Utils\Microplate\CoordinateSystem12Well;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
+use MLL\Utils\Microplate\CoordinateSystem4x3;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use MLL\Utils\Microplate\MicroplateSet\MicroplateSetABCDE;
 use PHPUnit\Framework\TestCase;
 
 final class MicroplateSetABCDETest extends TestCase
 {
-    public function testSetLocationFromSetPositionFor96WellPlatesOutOfRangeTooHigh(): void
+    public function testSetLocationFromSetPositionFor12x8PlatesOutOfRangeTooHigh(): void
     {
-        $microplateSet = new MicroplateSetABCDE(new CoordinateSystem96Well());
+        $microplateSet = new MicroplateSetABCDE(new CoordinateSystem12x8());
 
         $setPositionHigherThanMax = 481;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-480, got: {$setPositionHigherThanMax}"));
         $microplateSet->locationFromPosition($setPositionHigherThanMax, FlowDirection::COLUMN());
     }
 
-    public function testSetLocationFromSetPositionFor96WellPlatesOutOfRangeTooLow(): void
+    public function testSetLocationFromSetPositionFor12x8PlatesOutOfRangeTooLow(): void
     {
-        $microplateSet = new MicroplateSetABCDE(new CoordinateSystem96Well());
+        $microplateSet = new MicroplateSetABCDE(new CoordinateSystem12x8());
 
         $setPositionLowerThanMin = 0;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-480, got: {$setPositionLowerThanMin}"));
@@ -30,7 +30,7 @@ final class MicroplateSetABCDETest extends TestCase
 
     public function testSetLocationFromSetPositionFor12WellPlatesOutOfRangeTooHigh(): void
     {
-        $microplateSet = new MicroplateSetABCDE(new CoordinateSystem12Well());
+        $microplateSet = new MicroplateSetABCDE(new CoordinateSystem4x3());
 
         $setPositionHigherThanMax = 61;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-60, got: {$setPositionHigherThanMax}"));
@@ -39,7 +39,7 @@ final class MicroplateSetABCDETest extends TestCase
 
     public function testSetLocationFromSetPositionFor12WellPlatesOutOfRangeTooLow(): void
     {
-        $microplateSet = new MicroplateSetABCDE(new CoordinateSystem12Well());
+        $microplateSet = new MicroplateSetABCDE(new CoordinateSystem4x3());
 
         $setPositionLowerThanMin = 0;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-60, got: {$setPositionLowerThanMin}"));

--- a/tests/Microplate/MicroplateSet/MicroplateSetABCDTest.php
+++ b/tests/Microplate/MicroplateSet/MicroplateSetABCDTest.php
@@ -2,8 +2,8 @@
 
 namespace MLL\Utils\Tests\Microplate\MicroplateSet;
 
-use MLL\Utils\Microplate\CoordinateSystem12Well;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
+use MLL\Utils\Microplate\CoordinateSystem4x3;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use MLL\Utils\Microplate\MicroplateSet\MicroplateSetABCD;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -11,18 +11,18 @@ use PHPUnit\Framework\TestCase;
 
 final class MicroplateSetABCDTest extends TestCase
 {
-    public function testSetLocationFromSetPositionFor96WellPlatesOutOfRangeTooHigh(): void
+    public function testSetLocationFromSetPositionFor12x8lPlatesOutOfRangeTooHigh(): void
     {
-        $microplateSet = new MicroplateSetABCD(new CoordinateSystem96Well());
+        $microplateSet = new MicroplateSetABCD(new CoordinateSystem12x8());
 
         $setPositionHigherThanMax = 385;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-384, got: {$setPositionHigherThanMax}"));
         $microplateSet->locationFromPosition($setPositionHigherThanMax, FlowDirection::COLUMN());
     }
 
-    public function testSetLocationFromSetPositionFor96WellPlatesOutOfRangeTooLow(): void
+    public function testSetLocationFromSetPositionFor12x8PlatesOutOfRangeTooLow(): void
     {
-        $microplateSet = new MicroplateSetABCD(new CoordinateSystem96Well());
+        $microplateSet = new MicroplateSetABCD(new CoordinateSystem12x8());
 
         $setPositionLowerThanMin = 0;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-384, got: {$setPositionLowerThanMin}"));
@@ -31,7 +31,7 @@ final class MicroplateSetABCDTest extends TestCase
 
     public function testSetLocationFromSetPositionFor12WellPlatesOutOfRangeTooHigh(): void
     {
-        $microplateSet = new MicroplateSetABCD(new CoordinateSystem12Well());
+        $microplateSet = new MicroplateSetABCD(new CoordinateSystem4x3());
 
         $setPositionHigherThanMax = 49;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-48, got: {$setPositionHigherThanMax}"));
@@ -40,7 +40,7 @@ final class MicroplateSetABCDTest extends TestCase
 
     public function testSetLocationFromSetPositionFor12WellPlatesOutOfRangeTooLow(): void
     {
-        $microplateSet = new MicroplateSetABCD(new CoordinateSystem12Well());
+        $microplateSet = new MicroplateSetABCD(new CoordinateSystem4x3());
 
         $setPositionLowerThanMin = 0;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-48, got: {$setPositionLowerThanMin}"));
@@ -51,7 +51,7 @@ final class MicroplateSetABCDTest extends TestCase
     #[DataProvider('dataProvider12Well')]
     public function testSetLocationFromSetPositionFor12Wells(int $position, string $coordinatesString, string $plateID): void
     {
-        $microplateSet = new MicroplateSetABCD(new CoordinateSystem12Well());
+        $microplateSet = new MicroplateSetABCD(new CoordinateSystem4x3());
 
         $location = $microplateSet->locationFromPosition($position, FlowDirection::COLUMN());
         self::assertSame($location->coordinates->toString(), $coordinatesString);
@@ -93,11 +93,11 @@ final class MicroplateSetABCDTest extends TestCase
         ];
     }
 
-    /** @dataProvider dataProvider96Well */
-    #[DataProvider('dataProvider96Well')]
-    public function testSetLocationFromSetPositionFor96Wells(int $position, string $coordinatesString, string $plateID): void
+    /** @dataProvider dataProvider12x8 */
+    #[DataProvider('dataProvider12x8')]
+    public function testSetLocationFromSetPositionFor12x8(int $position, string $coordinatesString, string $plateID): void
     {
-        $microplateSet = new MicroplateSetABCD(new CoordinateSystem96Well());
+        $microplateSet = new MicroplateSetABCD(new CoordinateSystem12x8());
 
         $location = $microplateSet->locationFromPosition($position, FlowDirection::COLUMN());
         self::assertSame($coordinatesString, $location->coordinates->toString());
@@ -105,7 +105,7 @@ final class MicroplateSetABCDTest extends TestCase
     }
 
     /** @return iterable<array{position: int, coordinatesString: string, plateID: string}> */
-    public static function dataProvider96Well(): iterable
+    public static function dataProvider12x8(): iterable
     {
         yield [
             'position' => 1,

--- a/tests/Microplate/MicroplateSet/MicroplateSetABTest.php
+++ b/tests/Microplate/MicroplateSet/MicroplateSetABTest.php
@@ -2,8 +2,8 @@
 
 namespace MLL\Utils\Tests\Microplate\MicroplateSet;
 
-use MLL\Utils\Microplate\CoordinateSystem12Well;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
+use MLL\Utils\Microplate\CoordinateSystem4x3;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use MLL\Utils\Microplate\MicroplateSet\MicroplateSetAB;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -11,18 +11,18 @@ use PHPUnit\Framework\TestCase;
 
 final class MicroplateSetABTest extends TestCase
 {
-    public function testSetLocationFromSetPositionFor96WellPlatesOutOfRangeTooHigh(): void
+    public function testSetLocationFromSetPositionFor12x8PlatesOutOfRangeTooHigh(): void
     {
-        $microplateSet = new MicroplateSetAB(new CoordinateSystem96Well());
+        $microplateSet = new MicroplateSetAB(new CoordinateSystem12x8());
 
         $setPositionHigherThanMax = 193;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-192, got: {$setPositionHigherThanMax}"));
         $microplateSet->locationFromPosition($setPositionHigherThanMax, FlowDirection::COLUMN());
     }
 
-    public function testSetLocationFromSetPositionFor96WellPlatesOutOfRangeTooLow(): void
+    public function testSetLocationFromSetPositionFor12x8PlatesOutOfRangeTooLow(): void
     {
-        $microplateSet = new MicroplateSetAB(new CoordinateSystem96Well());
+        $microplateSet = new MicroplateSetAB(new CoordinateSystem12x8());
 
         $setPositionLowerThanMin = 0;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-192, got: {$setPositionLowerThanMin}"));
@@ -31,7 +31,7 @@ final class MicroplateSetABTest extends TestCase
 
     public function testSetLocationFromSetPositionFor12WellPlatesOutOfRangeTooHigh(): void
     {
-        $microplateSet = new MicroplateSetAB(new CoordinateSystem12Well());
+        $microplateSet = new MicroplateSetAB(new CoordinateSystem4x3());
 
         $setPositionHigherThanMax = 25;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-24, got: {$setPositionHigherThanMax}"));
@@ -40,7 +40,7 @@ final class MicroplateSetABTest extends TestCase
 
     public function testSetLocationFromSetPositionFor12WellPlatesOutOfRangeTooLow(): void
     {
-        $microplateSet = new MicroplateSetAB(new CoordinateSystem12Well());
+        $microplateSet = new MicroplateSetAB(new CoordinateSystem4x3());
 
         $setPositionLowerThanMin = 0;
         self::expectExceptionObject(new \OutOfRangeException("Expected a position between 1-24, got: {$setPositionLowerThanMin}"));
@@ -51,7 +51,7 @@ final class MicroplateSetABTest extends TestCase
     #[DataProvider('dataProvider12Well')]
     public function testSetLocationFromSetPositionFor12Wells(int $position, string $coordinatesString, string $plateID): void
     {
-        $microplateSet = new MicroplateSetAB(new CoordinateSystem12Well());
+        $microplateSet = new MicroplateSetAB(new CoordinateSystem4x3());
 
         $location = $microplateSet->locationFromPosition($position, FlowDirection::COLUMN());
         self::assertSame($location->coordinates->toString(), $coordinatesString);
@@ -93,11 +93,11 @@ final class MicroplateSetABTest extends TestCase
         ];
     }
 
-    /** @dataProvider dataProvider96Well */
-    #[DataProvider('dataProvider96Well')]
-    public function testSetLocationFromSetPositionFor96Wells(int $position, string $coordinatesString, string $plateID): void
+    /** @dataProvider dataProvider12x8 */
+    #[DataProvider('dataProvider12x8')]
+    public function testSetLocationFromSetPositionFor12x8(int $position, string $coordinatesString, string $plateID): void
     {
-        $microplateSet = new MicroplateSetAB(new CoordinateSystem96Well());
+        $microplateSet = new MicroplateSetAB(new CoordinateSystem12x8());
 
         $location = $microplateSet->locationFromPosition($position, FlowDirection::COLUMN());
         self::assertSame($coordinatesString, $location->coordinates->toString());
@@ -111,7 +111,7 @@ final class MicroplateSetABTest extends TestCase
      *   plateID: string,
      * }>
      */
-    public static function dataProvider96Well(): iterable
+    public static function dataProvider12x8(): iterable
     {
         yield [
             'position' => 1,

--- a/tests/Microplate/MicroplateSetTest.php
+++ b/tests/Microplate/MicroplateSetTest.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tests\Microplate;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\MicroplateSet\MicroplateSetAB;
 use MLL\Utils\Microplate\MicroplateSet\MicroplateSetABCD;
 use MLL\Utils\Microplate\MicroplateSet\MicroplateSetABCDE;
@@ -12,7 +12,7 @@ final class MicroplateSetTest extends TestCase
 {
     public function testPlateCount(): void
     {
-        $anyCoordinateSystemWillDo = new CoordinateSystem96Well();
+        $anyCoordinateSystemWillDo = new CoordinateSystem12x8();
 
         self::assertSame(MicroplateSetAB::PLATE_COUNT, (new MicroplateSetAB($anyCoordinateSystemWillDo))->plateCount());
         self::assertSame(MicroplateSetABCD::PLATE_COUNT, (new MicroplateSetABCD($anyCoordinateSystemWillDo))->plateCount());

--- a/tests/Microplate/MicroplateTest.php
+++ b/tests/Microplate/MicroplateTest.php
@@ -4,8 +4,8 @@ namespace MLL\Utils\Tests\Microplate;
 
 use Illuminate\Support\Collection;
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem12Well;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
+use MLL\Utils\Microplate\CoordinateSystem4x3;
 use MLL\Utils\Microplate\Enums\FlowDirection;
 use MLL\Utils\Microplate\Exceptions\MicroplateIsFullException;
 use MLL\Utils\Microplate\Microplate;
@@ -16,7 +16,7 @@ final class MicroplateTest extends TestCase
 {
     public function testCanAddAndRetrieveWellBasedOnCoordinateSystem(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
 
         $microplate = new Microplate($coordinateSystem);
 
@@ -32,14 +32,14 @@ final class MicroplateTest extends TestCase
         self::assertEquals($wellContent1, $microplate->well($microplateCoordinate1));
         self::assertEquals($wellContent2, $microplate->well($microplateCoordinate2));
 
-        $coordinateWithOtherCoordinateSystem = new Coordinates('B', 2, new CoordinateSystem12Well());
+        $coordinateWithOtherCoordinateSystem = new Coordinates('B', 2, new CoordinateSystem4x3());
         // @phpstan-ignore-next-line expecting a type error due to mismatching coordinates
         $microplate->addWell($coordinateWithOtherCoordinateSystem, 'foo');
     }
 
     public function testMatchRow(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
 
         $microplate = new Microplate($coordinateSystem);
 
@@ -66,7 +66,7 @@ final class MicroplateTest extends TestCase
 
     public function testMatchColumn(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
 
         $microplate = new Microplate($coordinateSystem);
 
@@ -80,7 +80,7 @@ final class MicroplateTest extends TestCase
 
     public function testtoWellWithCoordinatesMapper(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $microplate = new Microplate($coordinateSystem);
 
         $coordinates = new Coordinates('A', 1, $coordinateSystem);
@@ -133,17 +133,17 @@ final class MicroplateTest extends TestCase
         self::assertNotCount(0, $microplate->freeWells());
     }
 
-    /** @phpstan-return Microplate<mixed, CoordinateSystem96Well> */
+    /** @phpstan-return Microplate<mixed, CoordinateSystem12x8> */
     private function preparePlate(): Microplate
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
 
         $microplate = new Microplate($coordinateSystem);
 
-        $data96Wells = CoordinatesTest::data96Wells();
-        \Safe\shuffle($data96Wells);
-        foreach ($data96Wells as $well) {
-            $microplateCoordinates = new Coordinates($well['row'], $well['column'], new CoordinateSystem96Well());
+        $data12x8 = CoordinatesTest::data12x8();
+        \Safe\shuffle($data12x8);
+        foreach ($data12x8 as $well) {
+            $microplateCoordinates = new Coordinates($well['row'], $well['column'], new CoordinateSystem12x8());
 
             $randomNumber = rand(1, 100);
             $randomNumberOrNull = $randomNumber > 50 ? $randomNumber : null;
@@ -156,7 +156,7 @@ final class MicroplateTest extends TestCase
 
     public function testNextFreeWellAddingAndGetting(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $microplate = new Microplate($coordinateSystem);
 
         $wellData = [
@@ -192,10 +192,10 @@ final class MicroplateTest extends TestCase
 
     public function testThrowsPlateFullException(): void
     {
-        $coordinateSystem = new CoordinateSystem12Well();
+        $coordinateSystem = new CoordinateSystem4x3();
         $microplate = new Microplate($coordinateSystem);
 
-        $dataProvider12Well = CoordinatesTest::data12Wells();
+        $dataProvider12Well = CoordinatesTest::data4x3();
         foreach ($dataProvider12Well as $wellData) {
             $microplateCoordinates = new Coordinates($wellData['row'], $wellData['column'], $coordinateSystem);
             // check that it does not throw before the plate is full
@@ -209,7 +209,7 @@ final class MicroplateTest extends TestCase
 
     public function testIsConsecutiveForColumn(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $microplate = new Microplate($coordinateSystem);
 
         $data = [
@@ -230,7 +230,7 @@ final class MicroplateTest extends TestCase
 
     public function testIsConsecutiveForRow(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $microplate = new Microplate($coordinateSystem);
 
         $data = [
@@ -251,7 +251,7 @@ final class MicroplateTest extends TestCase
 
     public function testIsConsecutiveForEmptyPlate(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $microplate = new Microplate($coordinateSystem);
 
         self::assertFalse($microplate->isConsecutive(FlowDirection::ROW()));
@@ -260,7 +260,7 @@ final class MicroplateTest extends TestCase
 
     public function testIsConsecutiveForFullPlate(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $microplate = new Microplate($coordinateSystem);
 
         foreach ($coordinateSystem->all() as $coordinates) {

--- a/tests/Microplate/SectionedMicroplate/FullColumnSectionTest.php
+++ b/tests/Microplate/SectionedMicroplate/FullColumnSectionTest.php
@@ -3,7 +3,7 @@
 namespace MLL\Utils\Tests\Microplate\SectionedMicroplate;
 
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\Exceptions\MicroplateIsFullException;
 use MLL\Utils\Microplate\Exceptions\SectionIsFullException;
 use MLL\Utils\Microplate\FullColumnSection;
@@ -14,7 +14,7 @@ final class FullColumnSectionTest extends TestCase
 {
     public function testFullColumnSectionThrowsWhenFull(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $sectionedMicroplate = new SectionedMicroplate($coordinateSystem);
         self::assertCount(0, $sectionedMicroplate->sections);
 
@@ -35,7 +35,7 @@ final class FullColumnSectionTest extends TestCase
 
     public function testCanNotAddFullColumnSectionIfAllColumnsAreReserved(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $sectionedMicroplate = new SectionedMicroplate($coordinateSystem);
 
         foreach (range(1, $coordinateSystem->columnsCount()) as $i) {
@@ -48,7 +48,7 @@ final class FullColumnSectionTest extends TestCase
 
     public function testCanNotGrowFullColumnSectionIfNoColumnsAreLeft(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $sectionedMicroplate = new SectionedMicroplate($coordinateSystem);
 
         foreach (range(1, $coordinateSystem->columnsCount() - 1) as $i) {
@@ -66,7 +66,7 @@ final class FullColumnSectionTest extends TestCase
 
     public function testFullColumnSection(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $sectionedMicroplate = new SectionedMicroplate($coordinateSystem);
         self::assertCount(0, $sectionedMicroplate->sections);
 

--- a/tests/Microplate/SectionedMicroplate/SectionTest.php
+++ b/tests/Microplate/SectionedMicroplate/SectionTest.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tests\Microplate\SectionedMicroplate;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\Exceptions\MicroplateIsFullException;
 use MLL\Utils\Microplate\Section;
 use MLL\Utils\Microplate\SectionedMicroplate;
@@ -12,7 +12,7 @@ final class SectionTest extends TestCase
 {
     public function testSectionThrowsWhenFull(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $sectionedMicroplate = new SectionedMicroplate($coordinateSystem);
         self::assertCount(0, $sectionedMicroplate->sections);
 

--- a/tests/Microplate/SectionedMicroplate/SectionedMicroplateTest.php
+++ b/tests/Microplate/SectionedMicroplate/SectionedMicroplateTest.php
@@ -2,7 +2,7 @@
 
 namespace MLL\Utils\Tests\Microplate\SectionedMicroplate;
 
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\Section;
 use MLL\Utils\Microplate\SectionedMicroplate;
 use PHPUnit\Framework\TestCase;
@@ -11,7 +11,7 @@ final class SectionedMicroplateTest extends TestCase
 {
     public function testCanAddSectionsAndWellsToSectionAndRemoveSections(): void
     {
-        $coordinateSystem = new CoordinateSystem96Well();
+        $coordinateSystem = new CoordinateSystem12x8();
         $sectionedMicroplate = new SectionedMicroplate($coordinateSystem);
         self::assertCount(0, $sectionedMicroplate->sections);
 

--- a/tests/QxManager/FilledWellTest.php
+++ b/tests/QxManager/FilledWellTest.php
@@ -3,7 +3,7 @@
 namespace MLL\Utils\Tests\QxManager;
 
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\QxManager\FilledRow;
 use MLL\Utils\QxManager\FilledWell;
 use PHPUnit\Framework\TestCase;
@@ -12,7 +12,7 @@ final class FilledWellTest extends TestCase
 {
     public function testToString(): void
     {
-        $coordinates = Coordinates::fromString('C9', new CoordinateSystem96Well());
+        $coordinates = Coordinates::fromString('C9', new CoordinateSystem12x8());
 
         $famRowMock = $this->createMock(FilledRow::class);
         $famRowMock->expects(self::once())

--- a/tests/QxManager/QxManagerSampleSheetTest.php
+++ b/tests/QxManager/QxManagerSampleSheetTest.php
@@ -4,7 +4,7 @@ namespace MLL\Utils\Tests\QxManager;
 
 use Carbon\Carbon;
 use MLL\Utils\Microplate\Coordinates;
-use MLL\Utils\Microplate\CoordinateSystem96Well;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\Microplate\Microplate;
 use MLL\Utils\QxManager\FilledRow;
 use MLL\Utils\QxManager\FilledWell;
@@ -28,15 +28,15 @@ final class QxManagerSampleSheetTest extends TestCase
 
         $filledWell = new FilledWell($famRowMock, $hexRowMock);
 
-        /** @var Microplate<FilledWell, CoordinateSystem96Well> $microplate */
-        $microplate = new Microplate(new CoordinateSystem96Well());
+        /** @var Microplate<FilledWell, CoordinateSystem12x8> $microplate */
+        $microplate = new Microplate(new CoordinateSystem12x8());
         $microplate->addWell(
-            Coordinates::fromString('F1', new CoordinateSystem96Well()),
+            Coordinates::fromString('F1', new CoordinateSystem12x8()),
             $filledWell
         );
 
         $microplate->addWell(
-            Coordinates::fromString('H12', new CoordinateSystem96Well()),
+            Coordinates::fromString('H12', new CoordinateSystem12x8()),
             $filledWell
         );
 
@@ -44,7 +44,7 @@ final class QxManagerSampleSheetTest extends TestCase
         $sampleSheet = new QxManagerSampleSheet();
         $csvString = $sampleSheet->toCsvString($microplate, $createdDate);
 
-        $expectedCsvString = <<<CSV
+        self::assertSame(StringUtil::normalizeLineEndings(<<<CSV
 ddplate - DO NOT MODIFY THIS LINE,Version=1,ApplicationName=QX Manager Standard Edition,ApplicationVersion=2.0.0.665,ApplicationEdition=ResearchEmbedded,User=\QX User,CreatedDate={$createdDate->format('n/j/Y g:i:s A')},
 
 PlateSize=GCR96
@@ -149,8 +149,6 @@ H11,No,,,,,,,,,,,,,,,,
 H12,FAM Row String
 H12,HEX Row String
 
-CSV;
-
-        self::assertSame(StringUtil::normalizeLineEndings($expectedCsvString), $csvString);
+CSV), $csvString);
     }
 }

--- a/tests/Tecan/CustomCommands/TransferWithAutoWashTest.php
+++ b/tests/Tecan/CustomCommands/TransferWithAutoWashTest.php
@@ -21,11 +21,11 @@ final class TransferWithAutoWashTest extends TestCase
         $transfer = new TransferWithAutoWash(100, $liquidClass, $aspirateLocation, $dispenseLocation);
 
         self::assertSame(
-            StringUtil::normalizeLineEndings(
-                'A;;;96FluidX;;barcode;100;TestLiquidClassName;;
+            StringUtil::normalizeLineEndings(<<<'CSV'
+A;;;96FluidX;;barcode;100;TestLiquidClassName;;
 D;;;96FluidX;;barcode1;100;TestLiquidClassName;;
-W;'
-            ),
+W;
+CSV),
             $transfer->toString()
         );
     }

--- a/tests/Tecan/Rack/RackTest.php
+++ b/tests/Tecan/Rack/RackTest.php
@@ -62,7 +62,7 @@ final class RackTest extends TestCase
         $rack->assignPosition('Sample', $lastPosition + 1);
     }
 
-    /** @return iterable<string, array{BaseRack<mixed>, string, string, int}> */
+    /** @return iterable<array{BaseRack<mixed>, string, string, int}> */
     public static function rackDataProvider(): iterable
     {
         yield 'MPCDNA' => [new MPCDNA(), 'MPCDNA', 'MP cDNA', 96];

--- a/tests/Tecan/TecanProtocolTest.php
+++ b/tests/Tecan/TecanProtocolTest.php
@@ -83,8 +83,7 @@ CSV
             );
         }
         self::assertSame(
-            StringUtil::normalizeLineEndings(
-                <<<CSV
+            StringUtil::normalizeLineEndings(<<<CSV
 {$this->initComment()}A;;;96FluidX;;barcode;100;TestLiquidClassName;;1
 D;;;96FluidX;;barcode1;100;TestLiquidClassName;;1
 W;
@@ -102,8 +101,7 @@ A;;;96FluidX;;barcode;100;TestLiquidClassName;;1
 D;;;96FluidX;;barcode1;100;TestLiquidClassName;;1
 W;
 
-CSV
-            ),
+CSV),
             $tecanProtocol->buildProtocol()
         );
     }
@@ -130,8 +128,7 @@ CSV
         }
 
         self::assertSame(
-            StringUtil::normalizeLineEndings(
-                <<<CSV
+            StringUtil::normalizeLineEndings(<<<CSV
 {$this->initComment()}A;;;96FluidX;;barcode;100;TestLiquidClassName;;1
 D;;;96FluidX;;barcode1;100;TestLiquidClassName;;1
 W;
@@ -149,8 +146,7 @@ A;;;96FluidX;;barcode;100;TestLiquidClassName;;1
 D;;;96FluidX;;barcode1;100;TestLiquidClassName;;1
 W;
 
-CSV
-            ),
+CSV),
             $tecanProtocol->buildProtocol()
         );
     }
@@ -171,8 +167,7 @@ CSV
         }
 
         self::assertSame(
-            StringUtil::normalizeLineEndings(
-                <<<CSV
+            StringUtil::normalizeLineEndings(<<<CSV
 {$this->initComment()}A;;;96FluidX;;barcode;100;TestLiquidClassName;;1
 D;;;96FluidX;;barcode1;100;TestLiquidClassName;;1
 W;
@@ -205,8 +200,7 @@ A;;;96FluidX;;barcode;100;TestLiquidClassName;;2
 D;;;96FluidX;;barcode1;100;TestLiquidClassName;;2
 W;
 
-CSV
-            ),
+CSV),
             $tecanProtocol->buildProtocol()
         );
     }
@@ -280,8 +274,7 @@ CSV
         );
 
         self::assertSame(
-            StringUtil::normalizeLineEndings(
-                <<<CSV
+            StringUtil::normalizeLineEndings(<<<CSV
 {$this->initComment()}R;MM;;Eppis 32x1.5 ml Cooled;1;1;DestPCR;;96 Well PCR ABI semi-skirted;1;57;24;Transfer_Mastermix_MP;6;1;0;6;7;8;9;10;11;12;13;14;15;16;17;18;19;20;21;22;23;24;25;26;27;28;29;30;31;32;33;34;35;36;37;38;39;40;41;42;43;44;45;46;47;48;49;50;51;52;53;54;55;56
 R;MM;;Eppis 32x1.5 ml Cooled;2;2;DestPCR;;96 Well PCR ABI semi-skirted;6;75;24;Transfer_Mastermix_MP;6;1;0;8;9;10;11;12;13;14;15;16;17;18;19;20;21;22;23;24;25;26;27;28;29;30;31;32;33;34;35;36;37;38;39;40;41;42;43;44;45;46;47;48;49;51;52;53;54;55;56;57;59;60;61;62;63;64;65;66;67;68;69;70;71;72;73
 R;MM;;Eppis 32x1.5 ml Cooled;3;3;DestPCR;;96 Well PCR ABI semi-skirted;8;59;24;Transfer_Mastermix_MP;6;1;0;9;11;12;13;14;15;16;17;18;19;20;21;22;23;24;25;26;27;28;29;30;31;32;33;34;35;36;37;38;39;40;41;42;43;44;45;46;47;48;49;50;52;53;54;55;56;57;58
@@ -289,8 +282,7 @@ R;MM;;Eppis 32x1.5 ml Cooled;4;4;DestPCR;;96 Well PCR ABI semi-skirted;11;60;24;
 R;MM;;Eppis 32x1.5 ml Cooled;5;5;DestPCR;;96 Well PCR ABI semi-skirted;24;61;24;Transfer_Mastermix_MP;6;1;0;31;32;33;34;35;36;37;38;39;40;41;42;43;44;45;46;47;48;49;50;51;52;54;55;56;57;58;59;60
 R;MM;;Eppis 32x1.5 ml Cooled;5;5;DestPCR;;96 Well PCR ABI semi-skirted;1;5;24;Transfer_Mastermix_MP;6;1;0;
 
-CSV
-            ),
+CSV),
             $tecanProtocol->buildProtocol()
         );
     }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

Unifies naming coordinate system classes by the number of columns and rows, not by their count.

**Breaking changes**

None, but the old classes are deprecated.
