### PR TITLE
Allow `int` parts in `StringUtil::joinNonEmpty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ See [GitHub releases](https://github.com/mll-lab/php-utils/releases).
 
 ## Unreleased
 
+## v5.11.0
+
+### Added
+
+- Allow `int` parts in `StringUtil::joinNonEmpty`
+
 ## v5.10.0
 
 ### Added

--- a/src/FluidXPlate/FluidXScanner.php
+++ b/src/FluidXPlate/FluidXScanner.php
@@ -80,9 +80,7 @@ class FluidXScanner
         }
 
         if ($id === FluidXScanner::NO_READ) {
-            throw new ScanFluidXPlateException($barcodes === []
-                ? 'Weder Platten-Barcode noch Tube-Barcodes konnten gescannt werden. Bitte überprüfen Sie, dass die Platte korrekt in den FluidX-Scanner eingelegt wurde.'
-                : 'Platten-Barcode konnte nicht gescannt werden. Bitte überprüfen Sie, dass die Platte mit der korrekten Orientierung in den FluidX-Scanner eingelegt wurde.');
+            throw new ScanFluidXPlateException($barcodes === [] ? 'Weder Platten-Barcode noch Tube-Barcodes konnten gescannt werden. Bitte überprüfen Sie, dass die Platte korrekt in den FluidX-Scanner eingelegt wurde.' : 'Platten-Barcode konnte nicht gescannt werden. Bitte überprüfen Sie, dass die Platte mit der korrekten Orientierung in den FluidX-Scanner eingelegt wurde.');
         }
 
         $plate = new FluidXPlate($id);

--- a/src/FluidXPlate/FluidXScanner.php
+++ b/src/FluidXPlate/FluidXScanner.php
@@ -80,7 +80,10 @@ class FluidXScanner
         }
 
         if ($id === FluidXScanner::NO_READ) {
-            throw new ScanFluidXPlateException($barcodes === [] ? 'Weder Platten-Barcode noch Tube-Barcodes konnten gescannt werden. Bitte überprüfen Sie, dass die Platte korrekt in den FluidX-Scanner eingelegt wurde.' : 'Platten-Barcode konnte nicht gescannt werden. Bitte überprüfen Sie, dass die Platte mit der korrekten Orientierung in den FluidX-Scanner eingelegt wurde.');
+            $message = $barcodes === []
+                ? 'Weder Platten-Barcode noch Tube-Barcodes konnten gescannt werden. Bitte überprüfen Sie, dass die Platte korrekt in den FluidX-Scanner eingelegt wurde.'
+                : 'Platten-Barcode konnte nicht gescannt werden. Bitte überprüfen Sie, dass die Platte mit der korrekten Orientierung in den FluidX-Scanner eingelegt wurde.';
+            throw new ScanFluidXPlateException($message);
         }
 
         $plate = new FluidXPlate($id);

--- a/src/Microplate/Microplate.php
+++ b/src/Microplate/Microplate.php
@@ -72,9 +72,7 @@ class Microplate extends AbstractMicroplate
     private function assertIsWellEmpty(Coordinates $coordinates, $content): void
     {
         if (! $this->isWellEmpty($coordinates)) {
-            throw new WellNotEmptyException(
-                'Well with coordinates "' . $coordinates->toString() . '" is not empty. Use setWell() to overwrite the coordinate. Well content "' . serialize($content) . '" was not added.'
-            );
+            throw new WellNotEmptyException('Well with coordinates "' . $coordinates->toString() . '" is not empty. Use setWell() to overwrite the coordinate. Well content "' . serialize($content) . '" was not added.');
         }
     }
 

--- a/src/StringUtil.php
+++ b/src/StringUtil.php
@@ -21,7 +21,7 @@ class StringUtil
     /** https://en.wikipedia.org/wiki/Byte_order_mark#UTF-32 */
     public const UTF_32_LITTLE_ENDIAN_BOM = "\xFF\xFE\x00\x00";
 
-    /** @param iterable<string|null> $parts */
+    /** @param iterable<string|int|null> $parts */
     public static function joinNonEmpty(string $glue, iterable $parts): string
     {
         $nonEmptyParts = [];

--- a/tests/StringUtilTest.php
+++ b/tests/StringUtilTest.php
@@ -12,7 +12,7 @@ final class StringUtilTest extends TestCase
     /**
      * @dataProvider joinNonEmpty
      *
-     * @param iterable<string|null> $parts
+     * @param iterable<string|int|null> $parts
      */
     #[DataProvider('joinNonEmpty')]
     public function testJoinNonEmpty(string $expectedJoined, string $glue, iterable $parts): void
@@ -23,12 +23,12 @@ final class StringUtilTest extends TestCase
         );
     }
 
-    /** @return iterable<array{string, string, iterable<string|null>}> */
+    /** @return iterable<array{string, string, iterable<string|int|null>}> */
     public static function joinNonEmpty(): iterable
     {
-        yield ['a b', ' ', ['a', null, '', 'b']];
-        yield ['ab', '', ['a', null, '', 'b']];
-        yield ['a,b', ',', new Collection(['a', null, '', 'b'])];
+        yield ['a b 0', ' ', ['a', null, 'b', '', 0]];
+        yield ['ab1', '', ['a', null, '', 'b', 1]];
+        yield ['a,b,2', ',', new Collection(['a', 'b', 2, null, ''])];
     }
 
     /** @dataProvider shortenFirstname */


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

Allows concatennation of lists that contain `int` as well as `string`.

**Breaking changes**

None.