### PR TITLE
feat: Handle empty values in CSVArray as empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [GitHub releases](https://github.com/mll-lab/php-utils/releases).
 ### Added
 
 - Default missing columns to empty strings instead of throwing in `CSVArray::toArray`
+- Ensure extensibility by using `new static` over `new self` everywhere
 
 ## v5.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ See [GitHub releases](https://github.com/mll-lab/php-utils/releases).
 
 ## Unreleased
 
+
+## v5.12.0
+
+### Added
+
+- Handle empty values in CSVArray as empty string
+
 ## v5.11.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,11 @@ See [GitHub releases](https://github.com/mll-lab/php-utils/releases).
 
 ## Unreleased
 
-
 ## v5.12.0
 
 ### Added
 
-- Handle empty values in CSVArray as empty string
+- Default missing columns to empty strings instead of throwing in `CSVArray::toArray`
 
 ## v5.11.0
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,6 @@ parameters:
   # Install https://plugins.jetbrains.com/plugin/7677-awesome-console to make those links clickable
   editorUrl: '%%relFile%%:%%line%%'
   editorUrlTitle: '%%relFile%%:%%line%%'
+  ignoreErrors:
+  # This is a library, so it should be extendable
+  - '#Unsafe usage of new static.*#'

--- a/src/CSVArray.php
+++ b/src/CSVArray.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Arr;
 /** @phpstan-type CSVPrimitive bool|float|int|string|\Stringable|null */
 class CSVArray
 {
+    public const DEFAULT_EMPTY_VALUE = '';
+
     /**
      * TODO: fix parsing multiline-content in csv.
      *
@@ -36,12 +38,8 @@ class CSVArray
 
             /** @var array<int, string> $entries */
             $entries = str_getcsv($line, $delimiter, $enclosure, $escape);
-            if (count($entries) !== count($columnHeaders)) {
-                throw new \Exception("The number of columns in row {$index} does not match the headers in CSV: {$firstLine}");
-            }
-
             foreach ($columnHeaders as $columnIndex => $columnName) {
-                $result[$index + 1][$columnName] = $entries[$columnIndex];
+                $result[$index + 1][$columnName] = $entries[$columnIndex] ?? self::DEFAULT_EMPTY_VALUE;
             }
         }
 

--- a/src/IlluminaSampleSheet/V2/BclConvert/CycleType.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/CycleType.php
@@ -16,22 +16,22 @@ class CycleType
         $this->value = $value;
     }
 
-    public static function READ_CYCLE(): static
+    public static function READ_CYCLE(): self
     {
         return new static(self::READ_CYCLE);
     }
 
-    public static function TRIMMED_CYCLE(): static
+    public static function TRIMMED_CYCLE(): self
     {
         return new static(self::TRIMMED_CYCLE);
     }
 
-    public static function UMI_CYCLE(): static
+    public static function UMI_CYCLE(): self
     {
         return new static(self::UMI_CYCLE);
     }
 
-    public static function INDEX_CYCLE(): static
+    public static function INDEX_CYCLE(): self
     {
         return new static(self::INDEX_CYCLE);
     }

--- a/src/IlluminaSampleSheet/V2/BclConvert/CycleType.php
+++ b/src/IlluminaSampleSheet/V2/BclConvert/CycleType.php
@@ -16,23 +16,23 @@ class CycleType
         $this->value = $value;
     }
 
-    public static function READ_CYCLE(): self
+    public static function READ_CYCLE(): static
     {
-        return new self(self::READ_CYCLE);
+        return new static(self::READ_CYCLE);
     }
 
-    public static function TRIMMED_CYCLE(): self
+    public static function TRIMMED_CYCLE(): static
     {
-        return new self(self::TRIMMED_CYCLE);
+        return new static(self::TRIMMED_CYCLE);
     }
 
-    public static function UMI_CYCLE(): self
+    public static function UMI_CYCLE(): static
     {
-        return new self(self::UMI_CYCLE);
+        return new static(self::UMI_CYCLE);
     }
 
-    public static function INDEX_CYCLE(): self
+    public static function INDEX_CYCLE(): static
     {
-        return new self(self::INDEX_CYCLE);
+        return new static(self::INDEX_CYCLE);
     }
 }

--- a/src/IlluminaSampleSheet/V2/Enums/FastQCompressionFormat.php
+++ b/src/IlluminaSampleSheet/V2/Enums/FastQCompressionFormat.php
@@ -14,12 +14,12 @@ class FastQCompressionFormat
         $this->value = $value;
     }
 
-    public static function GZIP(): static
+    public static function GZIP(): self
     {
         return new static(self::GZIP);
     }
 
-    public static function DRAGEN(): static
+    public static function DRAGEN(): self
     {
         return new static(self::DRAGEN);
     }

--- a/src/IlluminaSampleSheet/V2/Enums/FastQCompressionFormat.php
+++ b/src/IlluminaSampleSheet/V2/Enums/FastQCompressionFormat.php
@@ -14,13 +14,13 @@ class FastQCompressionFormat
         $this->value = $value;
     }
 
-    public static function GZIP(): self
+    public static function GZIP(): static
     {
-        return new self(self::GZIP);
+        return new static(self::GZIP);
     }
 
-    public static function DRAGEN(): self
+    public static function DRAGEN(): static
     {
-        return new self(self::DRAGEN);
+        return new static(self::DRAGEN);
     }
 }

--- a/src/Microplate/Coordinates.php
+++ b/src/Microplate/Coordinates.php
@@ -50,11 +50,11 @@ class Coordinates
      * @param CoordinatesArray $coordinates
      * @param TCoord $coordinateSystem
      *
-     * @return self<TCoord>
+     * @return static<TCoord>
      */
-    public static function fromArray(array $coordinates, CoordinateSystem $coordinateSystem): self
+    public static function fromArray(array $coordinates, CoordinateSystem $coordinateSystem): static
     {
-        return new self($coordinates['row'], $coordinates['column'], $coordinateSystem);
+        return new static($coordinates['row'], $coordinates['column'], $coordinateSystem);
     }
 
     /**
@@ -62,9 +62,9 @@ class Coordinates
      *
      * @param TCoord $coordinateSystem
      *
-     * @return self<TCoord>
+     * @return static<TCoord>
      */
-    public static function fromString(string $coordinatesString, CoordinateSystem $coordinateSystem): self
+    public static function fromString(string $coordinatesString, CoordinateSystem $coordinateSystem): static
     {
         $rows = $coordinateSystem->rows();
         $rowsOptions = \implode('|', $rows);
@@ -88,7 +88,7 @@ class Coordinates
             throw new \InvalidArgumentException("Expected coordinates between {$firstValidExample} and {$lastValidExample} for {$coordinateSystemClass}, got: {$coordinatesString}.");
         }
 
-        return new self($matches[1], (int) $matches[2], $coordinateSystem);
+        return new static($matches[1], (int) $matches[2], $coordinateSystem);
     }
 
     /**
@@ -96,22 +96,22 @@ class Coordinates
      *
      * @param TCoord $coordinateSystem
      *
-     * @return self<TCoord>
+     * @return static<TCoord>
      */
-    public static function fromPosition(int $position, FlowDirection $direction, CoordinateSystem $coordinateSystem): self
+    public static function fromPosition(int $position, FlowDirection $direction, CoordinateSystem $coordinateSystem): static
     {
         self::assertPositionInRange($coordinateSystem, $position);
 
         switch ($direction->value) {
             case FlowDirection::COLUMN:
-                return new self(
+                return new static(
                     $coordinateSystem->rowForColumnFlowPosition($position),
                     $coordinateSystem->columnForColumnFlowPosition($position),
                     $coordinateSystem
                 );
 
             case FlowDirection::ROW:
-                return new self(
+                return new static(
                     $coordinateSystem->rowForRowFlowPosition($position),
                     $coordinateSystem->columnForRowFlowPosition($position),
                     $coordinateSystem

--- a/src/Microplate/Coordinates.php
+++ b/src/Microplate/Coordinates.php
@@ -50,7 +50,7 @@ class Coordinates
      * @param CoordinatesArray $coordinates
      * @param TCoord $coordinateSystem
      *
-     * @return static<TCoord>
+     * @return self<TCoord>
      */
     public static function fromArray(array $coordinates, CoordinateSystem $coordinateSystem): self
     {
@@ -62,7 +62,7 @@ class Coordinates
      *
      * @param TCoord $coordinateSystem
      *
-     * @return static<TCoord>
+     * @return self<TCoord>
      */
     public static function fromString(string $coordinatesString, CoordinateSystem $coordinateSystem): self
     {
@@ -96,7 +96,7 @@ class Coordinates
      *
      * @param TCoord $coordinateSystem
      *
-     * @return static<TCoord>
+     * @return self<TCoord>
      */
     public static function fromPosition(int $position, FlowDirection $direction, CoordinateSystem $coordinateSystem): self
     {

--- a/src/Microplate/Coordinates.php
+++ b/src/Microplate/Coordinates.php
@@ -52,7 +52,7 @@ class Coordinates
      *
      * @return static<TCoord>
      */
-    public static function fromArray(array $coordinates, CoordinateSystem $coordinateSystem): static
+    public static function fromArray(array $coordinates, CoordinateSystem $coordinateSystem): self
     {
         return new static($coordinates['row'], $coordinates['column'], $coordinateSystem);
     }
@@ -64,7 +64,7 @@ class Coordinates
      *
      * @return static<TCoord>
      */
-    public static function fromString(string $coordinatesString, CoordinateSystem $coordinateSystem): static
+    public static function fromString(string $coordinatesString, CoordinateSystem $coordinateSystem): self
     {
         $rows = $coordinateSystem->rows();
         $rowsOptions = \implode('|', $rows);
@@ -98,7 +98,7 @@ class Coordinates
      *
      * @return static<TCoord>
      */
-    public static function fromPosition(int $position, FlowDirection $direction, CoordinateSystem $coordinateSystem): static
+    public static function fromPosition(int $position, FlowDirection $direction, CoordinateSystem $coordinateSystem): self
     {
         self::assertPositionInRange($coordinateSystem, $position);
 

--- a/src/Microplate/Enums/FlowDirection.php
+++ b/src/Microplate/Enums/FlowDirection.php
@@ -14,13 +14,13 @@ class FlowDirection
         $this->value = $value;
     }
 
-    public static function ROW(): self
+    public static function ROW(): static
     {
-        return new self(self::ROW);
+        return new static(self::ROW);
     }
 
-    public static function COLUMN(): self
+    public static function COLUMN(): static
     {
-        return new self(self::COLUMN);
+        return new static(self::COLUMN);
     }
 }

--- a/src/Microplate/Enums/FlowDirection.php
+++ b/src/Microplate/Enums/FlowDirection.php
@@ -14,12 +14,12 @@ class FlowDirection
         $this->value = $value;
     }
 
-    public static function ROW(): static
+    public static function ROW(): self
     {
         return new static(self::ROW);
     }
 
-    public static function COLUMN(): static
+    public static function COLUMN(): self
     {
         return new static(self::COLUMN);
     }

--- a/src/Tecan/LiquidClass/MLLLiquidClass.php
+++ b/src/Tecan/LiquidClass/MLLLiquidClass.php
@@ -17,29 +17,29 @@ class MLLLiquidClass implements LiquidClass
         $this->value = $value;
     }
 
-    public static function DNA_DILUTION(): self
+    public static function DNA_DILUTION(): static
     {
-        return new self(self::DNA_DILUTION);
+        return new static(self::DNA_DILUTION);
     }
 
-    public static function DNA_DILUTION_WATER(): self
+    public static function DNA_DILUTION_WATER(): static
     {
-        return new self(self::DNA_DILUTION_WATER);
+        return new static(self::DNA_DILUTION_WATER);
     }
 
-    public static function TRANSFER_PCR_PRODUKT(): self
+    public static function TRANSFER_PCR_PRODUKT(): static
     {
-        return new self(self::TRANSFER_PCR_PRODUKT);
+        return new static(self::TRANSFER_PCR_PRODUKT);
     }
 
-    public static function TRANSFER_MASTERMIX_MP(): self
+    public static function TRANSFER_MASTERMIX_MP(): static
     {
-        return new self(self::TRANSFER_MASTERMIX_MP);
+        return new static(self::TRANSFER_MASTERMIX_MP);
     }
 
-    public static function TRANSFER_TEMPLATE(): self
+    public static function TRANSFER_TEMPLATE(): static
     {
-        return new self(self::TRANSFER_TEMPLATE);
+        return new static(self::TRANSFER_TEMPLATE);
     }
 
     public function name(): string

--- a/src/Tecan/LiquidClass/MLLLiquidClass.php
+++ b/src/Tecan/LiquidClass/MLLLiquidClass.php
@@ -17,27 +17,27 @@ class MLLLiquidClass implements LiquidClass
         $this->value = $value;
     }
 
-    public static function DNA_DILUTION(): static
+    public static function DNA_DILUTION(): self
     {
         return new static(self::DNA_DILUTION);
     }
 
-    public static function DNA_DILUTION_WATER(): static
+    public static function DNA_DILUTION_WATER(): self
     {
         return new static(self::DNA_DILUTION_WATER);
     }
 
-    public static function TRANSFER_PCR_PRODUKT(): static
+    public static function TRANSFER_PCR_PRODUKT(): self
     {
         return new static(self::TRANSFER_PCR_PRODUKT);
     }
 
-    public static function TRANSFER_MASTERMIX_MP(): static
+    public static function TRANSFER_MASTERMIX_MP(): self
     {
         return new static(self::TRANSFER_MASTERMIX_MP);
     }
 
-    public static function TRANSFER_TEMPLATE(): static
+    public static function TRANSFER_TEMPLATE(): self
     {
         return new static(self::TRANSFER_TEMPLATE);
     }

--- a/src/Tecan/ReagentDistribution/ReagentDistributionDirection.php
+++ b/src/Tecan/ReagentDistribution/ReagentDistributionDirection.php
@@ -14,13 +14,13 @@ class ReagentDistributionDirection
         $this->value = $value;
     }
 
-    public static function LEFT_TO_RIGHT(): self
+    public static function LEFT_TO_RIGHT(): static
     {
-        return new self(self::LEFT_TO_RIGHT);
+        return new static(self::LEFT_TO_RIGHT);
     }
 
-    public static function RIGHT_TO_LEFT(): self
+    public static function RIGHT_TO_LEFT(): static
     {
-        return new self(self::RIGHT_TO_LEFT);
+        return new static(self::RIGHT_TO_LEFT);
     }
 }

--- a/src/Tecan/ReagentDistribution/ReagentDistributionDirection.php
+++ b/src/Tecan/ReagentDistribution/ReagentDistributionDirection.php
@@ -14,12 +14,12 @@ class ReagentDistributionDirection
         $this->value = $value;
     }
 
-    public static function LEFT_TO_RIGHT(): static
+    public static function LEFT_TO_RIGHT(): self
     {
         return new static(self::LEFT_TO_RIGHT);
     }
 
-    public static function RIGHT_TO_LEFT(): static
+    public static function RIGHT_TO_LEFT(): self
     {
         return new static(self::RIGHT_TO_LEFT);
     }

--- a/src/Tecan/TipMask/TipMask.php
+++ b/src/Tecan/TipMask/TipMask.php
@@ -18,14 +18,14 @@ class TipMask
         $this->value = $value;
     }
 
-    public static function FOUR_TIPS(): self
+    public static function FOUR_TIPS(): static
     {
-        return new self(self::FOUR_TIPS);
+        return new static(self::FOUR_TIPS);
     }
 
-    public static function EIGHT_TIPS(): self
+    public static function EIGHT_TIPS(): static
     {
-        return new self(self::EIGHT_TIPS);
+        return new static(self::EIGHT_TIPS);
     }
 
     public static function firstTip(): int

--- a/src/Tecan/TipMask/TipMask.php
+++ b/src/Tecan/TipMask/TipMask.php
@@ -18,12 +18,12 @@ class TipMask
         $this->value = $value;
     }
 
-    public static function FOUR_TIPS(): static
+    public static function FOUR_TIPS(): self
     {
         return new static(self::FOUR_TIPS);
     }
 
-    public static function EIGHT_TIPS(): static
+    public static function EIGHT_TIPS(): self
     {
         return new static(self::EIGHT_TIPS);
     }

--- a/tests/CSVArrayTest.php
+++ b/tests/CSVArrayTest.php
@@ -155,7 +155,7 @@ final class CSVArrayTest extends TestCase
                 . "Wert12\r\n"
                 . ";\r\n"
                 . "\r\n"
-                . "Wert14;Wert24;Wert34",
+                . 'Wert14;Wert24;Wert34',
             )
         );
     }

--- a/tests/CSVArrayTest.php
+++ b/tests/CSVArrayTest.php
@@ -144,7 +144,7 @@ final class CSVArrayTest extends TestCase
                     'Spalte1' => '',
                     'Spalte2' => '',
                 ],
-                4 => [
+                5 => [
                     'Spalte1' => 'Wert14',
                     'Spalte2' => 'Wert24',
                 ],
@@ -155,7 +155,8 @@ final class CSVArrayTest extends TestCase
                 . "Wert12\r\n"
                 . ";\r\n"
                 . "\r\n"
-                . 'Wert14;Wert24;Wert34',
+                . 'Wert14;Wert24;Wert34'
+                . "\r\n"
             )
         );
     }

--- a/tests/CSVArrayTest.php
+++ b/tests/CSVArrayTest.php
@@ -128,6 +128,27 @@ final class CSVArrayTest extends TestCase
         );
     }
 
+    public function testToArrayFillsUpEmptyValuesWithEmptyStrings(): void
+    {
+        self::assertSame(
+            [
+                1 => [
+                    'Spalte1' => 'Wert11',
+                    'Spalte2' => 'Wert21',
+                ],
+                2 => [
+                    'Spalte1' => 'Wert12',
+                    'Spalte2' => CSVArray::DEFAULT_EMPTY_VALUE,
+                ],
+            ],
+            CSVArray::toArray(
+                "Spalte1;Spalte2\r\n"
+                . "Wert11;Wert21\r\n"
+                . "Wert12\r\n",
+            )
+        );
+    }
+
     public function testHandlesMultilineStrings(): void
     {
         $multilineCsv = <<<CSV

--- a/tests/CSVArrayTest.php
+++ b/tests/CSVArrayTest.php
@@ -128,7 +128,7 @@ final class CSVArrayTest extends TestCase
         );
     }
 
-    public function testToArrayFillsUpEmptyValuesWithEmptyStrings(): void
+    public function testToArrayDefaultsMissingColumnsToEmptyStrings(): void
     {
         self::assertSame(
             [
@@ -140,11 +140,22 @@ final class CSVArrayTest extends TestCase
                     'Spalte1' => 'Wert12',
                     'Spalte2' => CSVArray::DEFAULT_EMPTY_VALUE,
                 ],
+                3 => [
+                    'Spalte1' => '',
+                    'Spalte2' => '',
+                ],
+                4 => [
+                    'Spalte1' => 'Wert14',
+                    'Spalte2' => 'Wert24',
+                ],
             ],
             CSVArray::toArray(
                 "Spalte1;Spalte2\r\n"
                 . "Wert11;Wert21\r\n"
-                . "Wert12\r\n",
+                . "Wert12\r\n"
+                . ";\r\n"
+                . "\r\n"
+                . "Wert14;Wert24;Wert34",
             )
         );
     }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

- Default missing columns to empty strings instead of throwing in `CSVArray::toArray`
- Ensure extensibility by using `new static` over `new self` everywhere
