### PR TITLE
feat: Add `next()` method to Coordinates class to return the next coordinate in the specified flow direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ See [GitHub releases](https://github.com/mll-lab/php-utils/releases).
 
 ## Unreleased
 
+## v5.17.0
+
+### Added
+
+- Add `next()` method to Coordinates to return the next coordinate in the specified flow direction
+
 ## v5.16.0
 
 ### Added

--- a/src/Microplate/Coordinates.php
+++ b/src/Microplate/Coordinates.php
@@ -167,6 +167,21 @@ class Coordinates
             && $coordinates->coordinateSystem->equals($this->coordinateSystem);
     }
 
+    /**
+     * Returns the next coordinate in the specified flow direction.
+     *
+     * @return static<TCoordinateSystem>
+     */
+    public function next(FlowDirection $direction): self
+    {
+        $currentPosition = $this->position($direction);
+        if ($currentPosition >= $this->coordinateSystem->positionsCount()) {
+            throw new \OutOfBoundsException('No next coordinate available: already at the last position.');
+        }
+
+        return self::fromPosition($currentPosition + 1, $direction, $this->coordinateSystem);
+    }
+
     private static function assertPositionInRange(CoordinateSystem $coordinateSystem, int $position): void
     {
         if (! in_array($position, range(self::MIN_POSITION, $coordinateSystem->positionsCount()), true)) {

--- a/tests/Microplate/CoordinatesTest.php
+++ b/tests/Microplate/CoordinatesTest.php
@@ -545,4 +545,45 @@ final class CoordinatesTest extends TestCase
             ['row' => 'H', 'column' => 12, 'rowFlowPosition' => 96, 'columnFlowPosition' => 96],
         ];
     }
+
+    /** @dataProvider nextCoordinatesProvider */
+    public function testNext(string $start, string $expected, FlowDirection $direction): void
+    {
+        $coordinateSystem = new CoordinateSystem4x3();
+        $coordinates = Coordinates::fromString($start, $coordinateSystem);
+        $next = $coordinates->next($direction);
+        self::assertSame($expected, $next->toString());
+    }
+
+    /** @return iterable<int, array{0: string, 1: string, 2: FlowDirection}> */
+    public static function nextCoordinatesProvider(): iterable
+    {
+        yield ['A1', 'B1', FlowDirection::COLUMN()];
+        yield ['B1', 'C1', FlowDirection::COLUMN()];
+        yield ['C1', 'A2', FlowDirection::COLUMN()];
+        yield ['A2', 'B2', FlowDirection::COLUMN()];
+        yield ['B2', 'C2', FlowDirection::COLUMN()];
+        yield ['C2', 'A3', FlowDirection::COLUMN()];
+        yield ['A3', 'B3', FlowDirection::COLUMN()];
+        yield ['B3', 'C3', FlowDirection::COLUMN()];
+
+        yield ['A1', 'A2', FlowDirection::ROW()];
+        yield ['A2', 'A3', FlowDirection::ROW()];
+        yield ['A3', 'A4', FlowDirection::ROW()];
+        yield ['A4', 'B1', FlowDirection::ROW()];
+        yield ['B1', 'B2', FlowDirection::ROW()];
+        yield ['B2', 'B3', FlowDirection::ROW()];
+        yield ['B3', 'B4', FlowDirection::ROW()];
+        yield ['B4', 'C1', FlowDirection::ROW()];
+        yield ['C1', 'C2', FlowDirection::ROW()];
+        yield ['C2', 'C3', FlowDirection::ROW()];
+    }
+
+    public function testNextThrowsOnLastPosition(): void
+    {
+        $coordinate = Coordinates::fromString('C4', new CoordinateSystem4x3());
+
+        $this->expectExceptionObject(new \OutOfBoundsException('No next coordinate available: already at the last position.'));
+        $coordinate->next(FlowDirection::ROW());
+    }
 }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

- Add `next()` method to Coordinates to return the next coordinate in the specified flow direction
