### PR TITLE
feat: add MolarityConverter and TapeStation CompactRegionTable parser

### DIFF
--- a/src/Concentration/MolarityConverter.php
+++ b/src/Concentration/MolarityConverter.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Concentration;
+
+class MolarityConverter
+{
+    /** Average molar mass of a single base pair in double-stranded DNA (g/mol). */
+    public const AVERAGE_DALTONS_PER_BASE_PAIR = 660.0;
+
+    /** Convert mass concentration (ng/µL) to molar concentration (nmol/L). */
+    public static function ngPerUlToNmolPerL(float $concentrationNgPerUl, int $averageFragmentSizeBp): float
+    {
+        assert($averageFragmentSizeBp > 0);
+
+        return ($concentrationNgPerUl / (self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSizeBp)) * 1_000_000;
+    }
+
+    /** Convert molar concentration (nmol/L) to mass concentration (ng/µL). */
+    public static function nmolPerLToNgPerUl(float $molarityNmolPerL, int $averageFragmentSizeBp): float
+    {
+        assert($averageFragmentSizeBp > 0);
+
+        return ($molarityNmolPerL * self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSizeBp) / 1_000_000;
+    }
+}

--- a/src/Concentration/MolarityConverter.php
+++ b/src/Concentration/MolarityConverter.php
@@ -8,18 +8,25 @@ class MolarityConverter
     public const AVERAGE_DALTONS_PER_BASE_PAIR = 660.0;
 
     /** Convert mass concentration (ng/µL) to molar concentration (nmol/L). */
-    public static function ngPerUlToNmolPerL(float $concentrationNgPerUl, int $averageFragmentSizeBp): float
+    public static function ngPerUlToNmolPerL(float $concentrationNgPerUl, float $averageFragmentSize): float
     {
-        assert($averageFragmentSizeBp > 0);
+        self::assertPositiveFragmentSize($averageFragmentSize);
 
-        return ($concentrationNgPerUl / (self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSizeBp)) * 1_000_000;
+        return ($concentrationNgPerUl / (self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSize)) * 1_000_000;
     }
 
     /** Convert molar concentration (nmol/L) to mass concentration (ng/µL). */
-    public static function nmolPerLToNgPerUl(float $molarityNmolPerL, int $averageFragmentSizeBp): float
+    public static function nmolPerLToNgPerUl(float $molarityNmolPerL, float $averageFragmentSize): float
     {
-        assert($averageFragmentSizeBp > 0);
+        self::assertPositiveFragmentSize($averageFragmentSize);
 
-        return ($molarityNmolPerL * self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSizeBp) / 1_000_000;
+        return ($molarityNmolPerL * self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSize) / 1_000_000;
+    }
+
+    private static function assertPositiveFragmentSize(float $averageFragmentSize): void
+    {
+        if ($averageFragmentSize <= 0.0) {
+            throw new \InvalidArgumentException("Fragment size must be positive, got {$averageFragmentSize}");
+        }
     }
 }

--- a/src/Concentration/MolarityConverter.php
+++ b/src/Concentration/MolarityConverter.php
@@ -7,7 +7,6 @@ class MolarityConverter
     /** Average molar mass of a single base pair in double-stranded DNA (g/mol). */
     public const AVERAGE_DALTONS_PER_BASE_PAIR = 660.0;
 
-    /** Convert mass concentration (ng/µL) to molar concentration (nmol/L). */
     public static function ngPerUlToNmolPerL(float $concentrationNgPerUl, float $averageFragmentSize): float
     {
         self::assertPositiveFragmentSize($averageFragmentSize);
@@ -15,7 +14,6 @@ class MolarityConverter
         return ($concentrationNgPerUl / (self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSize)) * 1_000_000;
     }
 
-    /** Convert molar concentration (nmol/L) to mass concentration (ng/µL). */
     public static function nmolPerLToNgPerUl(float $molarityNmolPerL, float $averageFragmentSize): float
     {
         self::assertPositiveFragmentSize($averageFragmentSize);

--- a/src/Concentration/MolarityConverter.php
+++ b/src/Concentration/MolarityConverter.php
@@ -8,7 +8,7 @@ class MolarityConverter
     public const DALTONS_PER_NUCLEOTIDE_SSDNA = 330.0;
     public const DALTONS_PER_NUCLEOTIDE_RNA = 340.0;
 
-    public static function concentrationToMolarity(
+    public static function massConcentrationToMolarity(
         float $concentrationNgPerUl,
         float $averageFragmentSize,
         float $averageDaltonsPerUnit
@@ -19,7 +19,7 @@ class MolarityConverter
         return ($concentrationNgPerUl / ($averageDaltonsPerUnit * $averageFragmentSize)) * 1_000_000;
     }
 
-    public static function molarityToConcentration(
+    public static function molarityToMassConcentration(
         float $molarityNmolPerL,
         float $averageFragmentSize,
         float $averageDaltonsPerUnit

--- a/src/Concentration/MolarityConverter.php
+++ b/src/Concentration/MolarityConverter.php
@@ -4,27 +4,36 @@ namespace MLL\Utils\Concentration;
 
 class MolarityConverter
 {
-    /** Average molar mass of a single base pair in double-stranded DNA (g/mol). */
-    public const AVERAGE_DALTONS_PER_BASE_PAIR = 660.0;
+    public const DALTONS_PER_BASE_PAIR_DSDNA = 660.0;
+    public const DALTONS_PER_NUCLEOTIDE_SSDNA = 330.0;
+    public const DALTONS_PER_NUCLEOTIDE_RNA = 340.0;
 
-    public static function ngPerUlToNmolPerL(float $concentrationNgPerUl, float $averageFragmentSize): float
-    {
-        self::assertPositiveFragmentSize($averageFragmentSize);
+    public static function concentrationToMolarity(
+        float $concentrationNgPerUl,
+        float $averageFragmentSize,
+        float $averageDaltonsPerUnit
+    ): float {
+        self::assertPositive($averageFragmentSize, 'Fragment size');
+        self::assertPositive($averageDaltonsPerUnit, 'Daltons per unit');
 
-        return ($concentrationNgPerUl / (self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSize)) * 1_000_000;
+        return ($concentrationNgPerUl / ($averageDaltonsPerUnit * $averageFragmentSize)) * 1_000_000;
     }
 
-    public static function nmolPerLToNgPerUl(float $molarityNmolPerL, float $averageFragmentSize): float
-    {
-        self::assertPositiveFragmentSize($averageFragmentSize);
+    public static function molarityToConcentration(
+        float $molarityNmolPerL,
+        float $averageFragmentSize,
+        float $averageDaltonsPerUnit
+    ): float {
+        self::assertPositive($averageFragmentSize, 'Fragment size');
+        self::assertPositive($averageDaltonsPerUnit, 'Daltons per unit');
 
-        return ($molarityNmolPerL * self::AVERAGE_DALTONS_PER_BASE_PAIR * $averageFragmentSize) / 1_000_000;
+        return ($molarityNmolPerL * $averageDaltonsPerUnit * $averageFragmentSize) / 1_000_000;
     }
 
-    private static function assertPositiveFragmentSize(float $averageFragmentSize): void
+    private static function assertPositive(float $value, string $name): void
     {
-        if ($averageFragmentSize <= 0.0) {
-            throw new \InvalidArgumentException("Fragment size must be positive, got {$averageFragmentSize}");
+        if ($value <= 0.0) {
+            throw new \InvalidArgumentException("{$name} must be positive, got {$value}");
         }
     }
 }

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -6,6 +6,19 @@ use Illuminate\Support\Collection;
 use MLL\Utils\CSVArray;
 use MLL\Utils\StringUtil;
 
+/**
+ * Parses Agilent TapeStation "Compact Region Table" CSV exports.
+ *
+ * Handles known format variations:
+ * - Delimiter: comma or semicolon (auto-detected)
+ * - Size columns: bp (DNA) or nt (RNA)
+ * - µ character encoding: UTF-8, Latin-1, or replacement character
+ * - From column: optional (absent in some exports)
+ *
+ * Currently only supports standard assays where concentration is in ng/µl
+ * and molarity in nmol/l. High Sensitivity assays (pg/µl, pmol/l) are
+ * rejected with a descriptive error — support can be added when needed.
+ */
 class CompactRegionTableParser
 {
     /**

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -4,6 +4,8 @@ namespace MLL\Utils\TapeStation;
 
 use Illuminate\Support\Collection;
 use MLL\Utils\CSVArray;
+use MLL\Utils\Microplate\Coordinates;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
 use MLL\Utils\StringUtil;
 
 /**
@@ -37,7 +39,7 @@ class CompactRegionTableParser
 
         return new CompactRegionTableRecord(
             $row['FileName'] ?? '',
-            $row['WellId'] ?? '',
+            Coordinates::fromString($row['WellId'] ?? '', new CoordinateSystem12x8()),
             $row['Sample Description'] ?? '',
             self::parseNullableInt($row, 'From [bp]', 'From [nt]'),
             self::parseInt($row, 'To [bp]', 'To [nt]'),

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -34,6 +34,10 @@ class CompactRegionTableParser
     /** @param array<string, string> $row */
     private static function recordFromRow(array $row): CompactRegionTableRecord
     {
+        if (array_key_exists('Region Molarity [pmol/l]', $row)) {
+            throw new \RuntimeException('High Sensitivity assay detected (pmol/l). This parser only supports standard assays (nmol/l).');
+        }
+
         return new CompactRegionTableRecord(
             $row['FileName'] ?? '',
             $row['WellId'] ?? '',
@@ -52,11 +56,19 @@ class CompactRegionTableParser
      * The concentration column header contains µ which may be corrupted.
      * Match by prefix instead of exact key.
      *
+     * Only standard assays (ng/µl) are supported. High Sensitivity assays
+     * export pg/µl which is 1000× smaller — using those values without
+     * conversion would produce dangerously wrong results.
+     *
      * @param array<string, string> $row
      */
     private static function parseConcentration(array $row): float
     {
         foreach ($row as $key => $value) {
+            if (strpos($key, 'Conc. [pg/') === 0) {
+                throw new \RuntimeException('High Sensitivity assay detected (pg/µl). This parser only supports standard assays (ng/µl).');
+            }
+
             if (strpos($key, self::CONCENTRATION_KEY_PREFIX) === 0) {
                 return self::parseFloat($value);
             }

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -27,9 +27,7 @@ class CompactRegionTableParser
         $rows = CSVArray::toArray($csvContent, $delimiter);
 
         return (new Collection($rows))
-            ->map(static function (array $row): CompactRegionTableRecord {
-                return self::recordFromRow($row);
-            });
+            ->map(static fn (array $row): CompactRegionTableRecord => self::recordFromRow($row));
     }
 
     /** @param array<string, string> $row */
@@ -70,9 +68,7 @@ class CompactRegionTableParser
         }
     }
 
-    /**
-     * @param array<string, string> $row
-     */
+    /** @param array<string, string> $row */
     private static function parseConcentration(array $row): float
     {
         foreach ($row as $key => $value) {

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\TapeStation;
+
+use Illuminate\Support\Collection;
+use MLL\Utils\CSVArray;
+use MLL\Utils\StringUtil;
+
+class CompactRegionTableParser
+{
+    /**
+     * Column name prefixes — used for fuzzy matching because the µ character
+     * in "Conc. [ng/µl]" is frequently corrupted during file save/load cycles.
+     */
+    private const CONCENTRATION_KEY_PREFIX = 'Conc. [ng/';
+    private const MOLARITY_KEY = 'Region Molarity [nmol/l]';
+
+    /** @return Collection<int, CompactRegionTableRecord> */
+    public static function parse(string $csvContent): Collection
+    {
+        $csvContent = StringUtil::toUTF8($csvContent);
+        $delimiter = self::detectDelimiter($csvContent);
+
+        $rows = CSVArray::toArray($csvContent, $delimiter);
+
+        $records = new Collection();
+        foreach ($rows as $row) {
+            $records->push(self::recordFromRow($row));
+        }
+
+        return $records;
+    }
+
+    /** @param array<string, string> $row */
+    private static function recordFromRow(array $row): CompactRegionTableRecord
+    {
+        return new CompactRegionTableRecord(
+            fileName: $row['FileName'] ?? '',
+            wellID: $row['WellId'] ?? '',
+            sampleDescription: $row['Sample Description'] ?? '',
+            fromBp: self::parseInt($row, 'From [bp]', 'From [nt]'),
+            toBp: self::parseInt($row, 'To [bp]', 'To [nt]'),
+            averageSizeBp: self::parseInt($row, 'Average Size [bp]', 'Average Size [nt]'),
+            concentrationNgPerUl: self::parseConcentration($row),
+            regionMolarityNmolPerL: self::parseFloat($row[self::MOLARITY_KEY] ?? '0'),
+            percentOfTotal: self::parseFloat($row['% of Total'] ?? '0'),
+            regionComment: $row['Region Comment'] ?? '',
+        );
+    }
+
+    /**
+     * The concentration column header contains µ which may be corrupted.
+     * Match by prefix instead of exact key.
+     *
+     * @param array<string, string> $row
+     */
+    private static function parseConcentration(array $row): float
+    {
+        foreach ($row as $key => $value) {
+            if (str_starts_with($key, self::CONCENTRATION_KEY_PREFIX)) {
+                return self::parseFloat($value);
+            }
+        }
+
+        throw new \RuntimeException('Concentration column not found. Expected column starting with "' . self::CONCENTRATION_KEY_PREFIX . '"');
+    }
+
+    /**
+     * Try primary key first, fall back to alternative (bp vs nt).
+     *
+     * @param array<string, string> $row
+     */
+    private static function parseInt(array $row, string $primaryKey, string $fallbackKey): int
+    {
+        $value = $row[$primaryKey] ?? $row[$fallbackKey] ?? null;
+        if ($value === null || $value === '') {
+            return 0;
+        }
+
+        return (int) round(self::parseFloat($value));
+    }
+
+    private static function parseFloat(string $value): float
+    {
+        $trimmed = trim($value);
+        if ($trimmed === '' || ! is_numeric($trimmed)) {
+            return 0.0;
+        }
+
+        return (float) $trimmed;
+    }
+
+    private static function detectDelimiter(string $csvContent): string
+    {
+        $firstLine = strtok($csvContent, "\n");
+        if ($firstLine === false) {
+            $firstLine = '';
+        }
+
+        $semicolonCount = substr_count($firstLine, ';');
+        $commaCount = substr_count($firstLine, ',');
+
+        return $semicolonCount > $commaCount ? ';' : ',';
+    }
+}

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -9,7 +9,7 @@ use MLL\Utils\StringUtil;
 /**
  * Parses Agilent TapeStation "Compact Region Table" CSV exports.
  *
- * Supports D1000, D5000, and RNA assays (all ng/µl + nmol/l).
+ * Supports all standard assays (D1000, D5000, RNA, Genomic DNA, Cell-free DNA — all ng/µl + nmol/l).
  * Rejects High Sensitivity assays (pg/µl + pmol/l) — see parseConcentration().
  */
 class CompactRegionTableParser

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -9,15 +9,8 @@ use MLL\Utils\StringUtil;
 /**
  * Parses Agilent TapeStation "Compact Region Table" CSV exports.
  *
- * Handles known format variations:
- * - Delimiter: comma or semicolon (auto-detected)
- * - Size columns: bp (DNA) or nt (RNA)
- * - µ character encoding: UTF-8, Latin-1, or replacement character
- * - From column: optional (absent in some exports)
- *
- * Currently only supports standard assays where concentration is in ng/µl
- * and molarity in nmol/l. High Sensitivity assays (pg/µl, pmol/l) are
- * rejected with a descriptive error — support can be added when needed.
+ * Supports D1000, D5000, and RNA assays (all ng/µl + nmol/l).
+ * Rejects High Sensitivity assays (pg/µl + pmol/l) — see parseConcentration().
  */
 class CompactRegionTableParser
 {

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -35,16 +35,16 @@ class CompactRegionTableParser
     private static function recordFromRow(array $row): CompactRegionTableRecord
     {
         return new CompactRegionTableRecord(
-            fileName: $row['FileName'] ?? '',
-            wellID: $row['WellId'] ?? '',
-            sampleDescription: $row['Sample Description'] ?? '',
-            fromBp: self::parseInt($row, 'From [bp]', 'From [nt]'),
-            toBp: self::parseInt($row, 'To [bp]', 'To [nt]'),
-            averageSizeBp: self::parseInt($row, 'Average Size [bp]', 'Average Size [nt]'),
-            concentrationNgPerUl: self::parseConcentration($row),
-            regionMolarityNmolPerL: self::parseFloat($row[self::MOLARITY_KEY] ?? '0'),
-            percentOfTotal: self::parseFloat($row['% of Total'] ?? '0'),
-            regionComment: $row['Region Comment'] ?? '',
+            $row['FileName'] ?? '',
+            $row['WellId'] ?? '',
+            $row['Sample Description'] ?? '',
+            self::parseInt($row, 'From [bp]', 'From [nt]'),
+            self::parseInt($row, 'To [bp]', 'To [nt]'),
+            self::parseInt($row, 'Average Size [bp]', 'Average Size [nt]'),
+            self::parseConcentration($row),
+            self::parseFloat($row[self::MOLARITY_KEY] ?? '0'),
+            self::parseFloat($row['% of Total'] ?? '0'),
+            $row['Region Comment'] ?? ''
         );
     }
 
@@ -57,7 +57,7 @@ class CompactRegionTableParser
     private static function parseConcentration(array $row): float
     {
         foreach ($row as $key => $value) {
-            if (str_starts_with($key, self::CONCENTRATION_KEY_PREFIX)) {
+            if (strpos($key, self::CONCENTRATION_KEY_PREFIX) === 0) {
                 return self::parseFloat($value);
             }
         }

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -10,14 +10,11 @@ use MLL\Utils\StringUtil;
  * Parses Agilent TapeStation "Compact Region Table" CSV exports.
  *
  * Supports all standard assays (D1000, D5000, RNA, Genomic DNA, Cell-free DNA — all ng/µl + nmol/l).
- * Rejects High Sensitivity assays (pg/µl + pmol/l) — see parseConcentration().
+ * Rejects High Sensitivity assays (pg/µl + pmol/l) — see rejectHighSensitivityAssay().
  */
 class CompactRegionTableParser
 {
-    /**
-     * Column name prefixes — used for fuzzy matching because the µ character
-     * in "Conc. [ng/µl]" is frequently corrupted during file save/load cycles.
-     */
+    /** µ in "Conc. [ng/µl]" is frequently corrupted during file save/load cycles. */
     private const CONCENTRATION_KEY_PREFIX = 'Conc. [ng/';
     private const MOLARITY_KEY = 'Region Molarity [nmol/l]';
 
@@ -29,20 +26,16 @@ class CompactRegionTableParser
 
         $rows = CSVArray::toArray($csvContent, $delimiter);
 
-        $records = new Collection();
-        foreach ($rows as $row) {
-            $records->push(self::recordFromRow($row));
-        }
-
-        return $records;
+        return (new Collection($rows))
+            ->map(static function (array $row): CompactRegionTableRecord {
+                return self::recordFromRow($row);
+            });
     }
 
     /** @param array<string, string> $row */
     private static function recordFromRow(array $row): CompactRegionTableRecord
     {
-        if (array_key_exists('Region Molarity [pmol/l]', $row)) {
-            throw new \RuntimeException('High Sensitivity assay detected (pmol/l). This parser only supports standard assays (nmol/l).');
-        }
+        self::rejectHighSensitivityAssay($row);
 
         return new CompactRegionTableRecord(
             $row['FileName'] ?? '',
@@ -59,22 +52,30 @@ class CompactRegionTableParser
     }
 
     /**
-     * The concentration column header contains µ which may be corrupted.
-     * Match by prefix instead of exact key.
+     * HS assays use pg/µl + pmol/l (1000× smaller than ng/µl + nmol/l).
+     * Silently parsing those would produce dangerously wrong results.
      *
-     * Only standard assays (ng/µl) are supported. High Sensitivity assays
-     * export pg/µl which is 1000× smaller — using those values without
-     * conversion would produce dangerously wrong results.
-     *
+     * @param array<string, string> $row
+     */
+    private static function rejectHighSensitivityAssay(array $row): void
+    {
+        if (array_key_exists('Region Molarity [pmol/l]', $row)) {
+            throw new \RuntimeException('High Sensitivity assay detected (pmol/l). This parser only supports standard assays (nmol/l).');
+        }
+
+        foreach (array_keys($row) as $key) {
+            if (strpos($key, 'Conc. [pg/') === 0) {
+                throw new \RuntimeException('High Sensitivity assay detected (pg/µl). This parser only supports standard assays (ng/µl).');
+            }
+        }
+    }
+
+    /**
      * @param array<string, string> $row
      */
     private static function parseConcentration(array $row): float
     {
         foreach ($row as $key => $value) {
-            if (strpos($key, 'Conc. [pg/') === 0) {
-                throw new \RuntimeException('High Sensitivity assay detected (pg/µl). This parser only supports standard assays (ng/µl).');
-            }
-
             if (strpos($key, self::CONCENTRATION_KEY_PREFIX) === 0) {
                 return self::parseFloat($value);
             }
@@ -83,12 +84,7 @@ class CompactRegionTableParser
         throw new \RuntimeException('Concentration column not found. Expected column starting with "' . self::CONCENTRATION_KEY_PREFIX . '"');
     }
 
-    /**
-     * Try primary key first, fall back to alternative (bp vs nt).
-     * Returns null when neither column exists in the header — e.g. From [bp] is absent in some exports.
-     *
-     * @param array<string, string> $row
-     */
+    /** @param array<string, string> $row */
     private static function parseNullableInt(array $row, string $primaryKey, string $fallbackKey): ?int
     {
         if (! array_key_exists($primaryKey, $row) && ! array_key_exists($fallbackKey, $row)) {
@@ -100,11 +96,7 @@ class CompactRegionTableParser
         return $value === '' ? null : (int) round(self::parseFloat($value));
     }
 
-    /**
-     * Try primary key first, fall back to alternative (bp vs nt).
-     *
-     * @param array<string, string> $row
-     */
+    /** @param array<string, string> $row */
     private static function parseInt(array $row, string $primaryKey, string $fallbackKey): int
     {
         $value = $row[$primaryKey] ?? $row[$fallbackKey] ?? null;

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -38,7 +38,7 @@ class CompactRegionTableParser
             $row['FileName'] ?? '',
             $row['WellId'] ?? '',
             $row['Sample Description'] ?? '',
-            self::parseInt($row, 'From [bp]', 'From [nt]'),
+            self::parseNullableInt($row, 'From [bp]', 'From [nt]'),
             self::parseInt($row, 'To [bp]', 'To [nt]'),
             self::parseInt($row, 'Average Size [bp]', 'Average Size [nt]'),
             self::parseConcentration($row),
@@ -63,6 +63,23 @@ class CompactRegionTableParser
         }
 
         throw new \RuntimeException('Concentration column not found. Expected column starting with "' . self::CONCENTRATION_KEY_PREFIX . '"');
+    }
+
+    /**
+     * Try primary key first, fall back to alternative (bp vs nt).
+     * Returns null when neither column exists in the header — e.g. From [bp] is absent in some exports.
+     *
+     * @param array<string, string> $row
+     */
+    private static function parseNullableInt(array $row, string $primaryKey, string $fallbackKey): ?int
+    {
+        if (! array_key_exists($primaryKey, $row) && ! array_key_exists($fallbackKey, $row)) {
+            return null;
+        }
+
+        $value = $row[$primaryKey] ?? $row[$fallbackKey] ?? '';
+
+        return $value === '' ? null : (int) round(self::parseFloat($value));
     }
 
     /**

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -43,11 +43,11 @@ class CompactRegionTableParser
             Coordinates::fromString($row['WellId'] ?? '', new CoordinateSystem12x8()),
             $row['Sample Description'] ?? '',
             self::parseNullableInt($row, 'From [bp]', 'From [nt]'),
-            self::parseInt($row, 'To [bp]', 'To [nt]'),
-            self::parseInt($row, 'Average Size [bp]', 'Average Size [nt]'),
+            SafeCast::toInt($row['To [bp]'] ?? $row['To [nt]'] ?? ''),
+            SafeCast::toInt($row['Average Size [bp]'] ?? $row['Average Size [nt]'] ?? ''),
             self::parseConcentration($row),
-            SafeCast::tryFloat($row[self::MOLARITY_KEY] ?? '0') ?? 0.0,
-            SafeCast::tryFloat($row['% of Total'] ?? '0') ?? 0.0,
+            SafeCast::toFloat($row[self::MOLARITY_KEY] ?? ''),
+            SafeCast::toFloat($row['% of Total'] ?? ''),
             $row['Region Comment'] ?? ''
         );
     }
@@ -76,7 +76,7 @@ class CompactRegionTableParser
     {
         foreach ($row as $key => $value) {
             if (strpos($key, self::CONCENTRATION_KEY_PREFIX) === 0) {
-                return SafeCast::tryFloat($value) ?? 0.0;
+                return SafeCast::toFloat($value);
             }
         }
 
@@ -92,26 +92,12 @@ class CompactRegionTableParser
 
         $value = $row[$primaryKey] ?? $row[$fallbackKey] ?? '';
 
-        return $value === '' ? null : (int) round(SafeCast::tryFloat($value) ?? 0.0);
-    }
-
-    /** @param array<string, string> $row */
-    private static function parseInt(array $row, string $primaryKey, string $fallbackKey): int
-    {
-        $value = $row[$primaryKey] ?? $row[$fallbackKey] ?? null;
-        if ($value === null || $value === '') {
-            return 0;
-        }
-
-        return (int) round(SafeCast::tryFloat($value) ?? 0.0);
+        return $value === '' ? null : SafeCast::toInt($value);
     }
 
     private static function detectDelimiter(string $csvContent): string
     {
-        $firstLine = strtok($csvContent, "\n");
-        if ($firstLine === false) {
-            $firstLine = '';
-        }
+        $firstLine = explode("\n", $csvContent, 2)[0];
 
         $semicolonCount = substr_count($firstLine, ';');
         $commaCount = substr_count($firstLine, ',');

--- a/src/TapeStation/CompactRegionTableParser.php
+++ b/src/TapeStation/CompactRegionTableParser.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use MLL\Utils\CSVArray;
 use MLL\Utils\Microplate\Coordinates;
 use MLL\Utils\Microplate\CoordinateSystem12x8;
+use MLL\Utils\SafeCast;
 use MLL\Utils\StringUtil;
 
 /**
@@ -45,8 +46,8 @@ class CompactRegionTableParser
             self::parseInt($row, 'To [bp]', 'To [nt]'),
             self::parseInt($row, 'Average Size [bp]', 'Average Size [nt]'),
             self::parseConcentration($row),
-            self::parseFloat($row[self::MOLARITY_KEY] ?? '0'),
-            self::parseFloat($row['% of Total'] ?? '0'),
+            SafeCast::tryFloat($row[self::MOLARITY_KEY] ?? '0') ?? 0.0,
+            SafeCast::tryFloat($row['% of Total'] ?? '0') ?? 0.0,
             $row['Region Comment'] ?? ''
         );
     }
@@ -75,7 +76,7 @@ class CompactRegionTableParser
     {
         foreach ($row as $key => $value) {
             if (strpos($key, self::CONCENTRATION_KEY_PREFIX) === 0) {
-                return self::parseFloat($value);
+                return SafeCast::tryFloat($value) ?? 0.0;
             }
         }
 
@@ -91,7 +92,7 @@ class CompactRegionTableParser
 
         $value = $row[$primaryKey] ?? $row[$fallbackKey] ?? '';
 
-        return $value === '' ? null : (int) round(self::parseFloat($value));
+        return $value === '' ? null : (int) round(SafeCast::tryFloat($value) ?? 0.0);
     }
 
     /** @param array<string, string> $row */
@@ -102,17 +103,7 @@ class CompactRegionTableParser
             return 0;
         }
 
-        return (int) round(self::parseFloat($value));
-    }
-
-    private static function parseFloat(string $value): float
-    {
-        $trimmed = trim($value);
-        if ($trimmed === '' || ! is_numeric($trimmed)) {
-            return 0.0;
-        }
-
-        return (float) $trimmed;
+        return (int) round(SafeCast::tryFloat($value) ?? 0.0);
     }
 
     private static function detectDelimiter(string $csvContent): string

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -13,7 +13,7 @@ class CompactRegionTableRecord
     /** @var string */
     public $sampleDescription;
 
-    /** @var int Region start in bp (DNA) or nt (RNA). */
+    /** @var int|null Region start in bp (DNA) or nt (RNA). Null when the column is absent from the export. */
     public $from;
 
     /** @var int Region end in bp (DNA) or nt (RNA). */
@@ -38,7 +38,7 @@ class CompactRegionTableRecord
         string $fileName,
         string $wellID,
         string $sampleDescription,
-        int $from,
+        ?int $from,
         int $to,
         int $averageSize,
         float $concentrationNgPerUl,

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -13,14 +13,14 @@ class CompactRegionTableRecord
     /** @var string */
     public $sampleDescription;
 
-    /** @var int */
-    public $fromBp;
+    /** @var int Region start in bp (DNA) or nt (RNA). */
+    public $from;
 
-    /** @var int */
-    public $toBp;
+    /** @var int Region end in bp (DNA) or nt (RNA). */
+    public $to;
 
-    /** @var int */
-    public $averageSizeBp;
+    /** @var int Average fragment size in bp (DNA) or nt (RNA). */
+    public $averageSize;
 
     /** @var float */
     public $concentrationNgPerUl;
@@ -38,9 +38,9 @@ class CompactRegionTableRecord
         string $fileName,
         string $wellID,
         string $sampleDescription,
-        int $fromBp,
-        int $toBp,
-        int $averageSizeBp,
+        int $from,
+        int $to,
+        int $averageSize,
         float $concentrationNgPerUl,
         float $regionMolarityNmolPerL,
         float $percentOfTotal,
@@ -49,9 +49,9 @@ class CompactRegionTableRecord
         $this->fileName = $fileName;
         $this->wellID = $wellID;
         $this->sampleDescription = $sampleDescription;
-        $this->fromBp = $fromBp;
-        $this->toBp = $toBp;
-        $this->averageSizeBp = $averageSizeBp;
+        $this->from = $from;
+        $this->to = $to;
+        $this->averageSize = $averageSize;
         $this->concentrationNgPerUl = $concentrationNgPerUl;
         $this->regionMolarityNmolPerL = $regionMolarityNmolPerL;
         $this->percentOfTotal = $percentOfTotal;

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -2,22 +2,6 @@
 
 namespace MLL\Utils\TapeStation;
 
-/**
- * A single row from an Agilent TapeStation "Compact Region Table" CSV export.
- *
- * This format is shared across assay types (D1000, HSD1000, RNA, etc.) — the
- * CSV structure is identical, only the units in column headers differ:
- * - D1000 (standard DNA): ng/µl, nmol/l, bp
- * - HSD1000 (high sensitivity DNA): pg/µl, pmol/l, bp
- * - RNA: ng/µl, nmol/l, nt
- *
- * The parser currently only accepts standard assays (ng/µl + nmol/l) and rejects
- * High Sensitivity assays with a clear error. The properties below are therefore
- * unit-agnostic — the caller knows which assay type it is parsing and is
- * responsible for interpreting units correctly.
- *
- * @see CompactRegionTableParser for format detection and validation
- */
 class CompactRegionTableRecord
 {
     /** @var string */
@@ -38,11 +22,11 @@ class CompactRegionTableRecord
     /** @var int Average fragment size in bp (DNA) or nt (RNA). */
     public $averageSize;
 
-    /** @var float Concentration from the "Conc." column. Unit depends on assay: ng/µl (standard) or pg/µl (HS). */
-    public $concentration;
+    /** @var float */
+    public $concentrationNgPerUl;
 
-    /** @var float Region molarity from the "Region Molarity" column. Unit depends on assay: nmol/l (standard) or pmol/l (HS). */
-    public $regionMolarity;
+    /** @var float */
+    public $regionMolarityNmolPerL;
 
     /** @var float */
     public $percentOfTotal;
@@ -57,8 +41,8 @@ class CompactRegionTableRecord
         ?int $from,
         int $to,
         int $averageSize,
-        float $concentration,
-        float $regionMolarity,
+        float $concentrationNgPerUl,
+        float $regionMolarityNmolPerL,
         float $percentOfTotal,
         string $regionComment
     ) {
@@ -68,8 +52,8 @@ class CompactRegionTableRecord
         $this->from = $from;
         $this->to = $to;
         $this->averageSize = $averageSize;
-        $this->concentration = $concentration;
-        $this->regionMolarity = $regionMolarity;
+        $this->concentrationNgPerUl = $concentrationNgPerUl;
+        $this->regionMolarityNmolPerL = $regionMolarityNmolPerL;
         $this->percentOfTotal = $percentOfTotal;
         $this->regionComment = $regionComment;
     }

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -2,6 +2,22 @@
 
 namespace MLL\Utils\TapeStation;
 
+/**
+ * A single row from an Agilent TapeStation "Compact Region Table" CSV export.
+ *
+ * This format is shared across assay types (D1000, HSD1000, RNA, etc.) — the
+ * CSV structure is identical, only the units in column headers differ:
+ * - D1000 (standard DNA): ng/µl, nmol/l, bp
+ * - HSD1000 (high sensitivity DNA): pg/µl, pmol/l, bp
+ * - RNA: ng/µl, nmol/l, nt
+ *
+ * The parser currently only accepts standard assays (ng/µl + nmol/l) and rejects
+ * High Sensitivity assays with a clear error. The properties below are therefore
+ * unit-agnostic — the caller knows which assay type it is parsing and is
+ * responsible for interpreting units correctly.
+ *
+ * @see CompactRegionTableParser for format detection and validation
+ */
 class CompactRegionTableRecord
 {
     /** @var string */
@@ -22,11 +38,11 @@ class CompactRegionTableRecord
     /** @var int Average fragment size in bp (DNA) or nt (RNA). */
     public $averageSize;
 
-    /** @var float */
-    public $concentrationNgPerUl;
+    /** @var float Concentration from the "Conc." column. Unit depends on assay: ng/µl (standard) or pg/µl (HS). */
+    public $concentration;
 
-    /** @var float */
-    public $regionMolarityNmolPerL;
+    /** @var float Region molarity from the "Region Molarity" column. Unit depends on assay: nmol/l (standard) or pmol/l (HS). */
+    public $regionMolarity;
 
     /** @var float */
     public $percentOfTotal;
@@ -41,8 +57,8 @@ class CompactRegionTableRecord
         ?int $from,
         int $to,
         int $averageSize,
-        float $concentrationNgPerUl,
-        float $regionMolarityNmolPerL,
+        float $concentration,
+        float $regionMolarity,
         float $percentOfTotal,
         string $regionComment
     ) {
@@ -52,8 +68,8 @@ class CompactRegionTableRecord
         $this->from = $from;
         $this->to = $to;
         $this->averageSize = $averageSize;
-        $this->concentrationNgPerUl = $concentrationNgPerUl;
-        $this->regionMolarityNmolPerL = $regionMolarityNmolPerL;
+        $this->concentration = $concentration;
+        $this->regionMolarity = $regionMolarity;
         $this->percentOfTotal = $percentOfTotal;
         $this->regionComment = $regionComment;
     }

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\TapeStation;
+
+readonly class CompactRegionTableRecord
+{
+    public function __construct(
+        public string $fileName,
+        public string $wellID,
+        public string $sampleDescription,
+        public int $fromBp,
+        public int $toBp,
+        public int $averageSizeBp,
+        public float $concentrationNgPerUl,
+        public float $regionMolarityNmolPerL,
+        public float $percentOfTotal,
+        public string $regionComment,
+    ) {}
+}

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -19,7 +19,7 @@ class CompactRegionTableRecord
     /** @var int Region end in bp (DNA) or nt (RNA). */
     public $to;
 
-    /** @var int Average fragment size in bp (DNA) or nt (RNA). */
+    /** @var int Average fragment size in bp (DNA) or nt (RNA). Center of mass, not peak maximum. */
     public $averageSize;
 
     /** @var float */

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -2,18 +2,59 @@
 
 namespace MLL\Utils\TapeStation;
 
-readonly class CompactRegionTableRecord
+class CompactRegionTableRecord
 {
+    /** @var string */
+    public $fileName;
+
+    /** @var string */
+    public $wellID;
+
+    /** @var string */
+    public $sampleDescription;
+
+    /** @var int */
+    public $fromBp;
+
+    /** @var int */
+    public $toBp;
+
+    /** @var int */
+    public $averageSizeBp;
+
+    /** @var float */
+    public $concentrationNgPerUl;
+
+    /** @var float */
+    public $regionMolarityNmolPerL;
+
+    /** @var float */
+    public $percentOfTotal;
+
+    /** @var string */
+    public $regionComment;
+
     public function __construct(
-        public string $fileName,
-        public string $wellID,
-        public string $sampleDescription,
-        public int $fromBp,
-        public int $toBp,
-        public int $averageSizeBp,
-        public float $concentrationNgPerUl,
-        public float $regionMolarityNmolPerL,
-        public float $percentOfTotal,
-        public string $regionComment,
-    ) {}
+        string $fileName,
+        string $wellID,
+        string $sampleDescription,
+        int $fromBp,
+        int $toBp,
+        int $averageSizeBp,
+        float $concentrationNgPerUl,
+        float $regionMolarityNmolPerL,
+        float $percentOfTotal,
+        string $regionComment
+    ) {
+        $this->fileName = $fileName;
+        $this->wellID = $wellID;
+        $this->sampleDescription = $sampleDescription;
+        $this->fromBp = $fromBp;
+        $this->toBp = $toBp;
+        $this->averageSizeBp = $averageSizeBp;
+        $this->concentrationNgPerUl = $concentrationNgPerUl;
+        $this->regionMolarityNmolPerL = $regionMolarityNmolPerL;
+        $this->percentOfTotal = $percentOfTotal;
+        $this->regionComment = $regionComment;
+    }
 }

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -2,11 +2,15 @@
 
 namespace MLL\Utils\TapeStation;
 
+use MLL\Utils\Microplate\Coordinates;
+use MLL\Utils\Microplate\CoordinateSystem12x8;
+
 class CompactRegionTableRecord
 {
     public string $fileName;
 
-    public string $wellID;
+    /** @var Coordinates<CoordinateSystem12x8> */
+    public Coordinates $wellID;
 
     public string $sampleDescription;
 
@@ -26,9 +30,10 @@ class CompactRegionTableRecord
 
     public string $regionComment;
 
+    /** @param Coordinates<CoordinateSystem12x8> $wellID */
     public function __construct(
         string $fileName,
-        string $wellID,
+        Coordinates $wellID,
         string $sampleDescription,
         ?int $from,
         int $to,

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -4,35 +4,27 @@ namespace MLL\Utils\TapeStation;
 
 class CompactRegionTableRecord
 {
-    /** @var string */
-    public $fileName;
+    public string $fileName;
 
-    /** @var string */
-    public $wellID;
+    public string $wellID;
 
-    /** @var string */
-    public $sampleDescription;
+    public string $sampleDescription;
 
-    /** @var int|null Region start in bp (DNA) or nt (RNA). Null when the column is absent from the export. */
-    public $from;
+    /** Null when the column is absent from the export. */
+    public ?int $from;
 
-    /** @var int Region end in bp (DNA) or nt (RNA). */
-    public $to;
+    public int $to;
 
-    /** @var int Average fragment size in bp (DNA) or nt (RNA). Center of mass, not peak maximum. */
-    public $averageSize;
+    /** Center of mass, not peak maximum. */
+    public int $averageSize;
 
-    /** @var float */
-    public $concentrationNgPerUl;
+    public float $concentrationNgPerUl;
 
-    /** @var float */
-    public $regionMolarityNmolPerL;
+    public float $regionMolarityNmolPerL;
 
-    /** @var float */
-    public $percentOfTotal;
+    public float $percentOfTotal;
 
-    /** @var string */
-    public $regionComment;
+    public string $regionComment;
 
     public function __construct(
         string $fileName,

--- a/src/TapeStation/CompactRegionTableRecord.php
+++ b/src/TapeStation/CompactRegionTableRecord.php
@@ -10,7 +10,7 @@ class CompactRegionTableRecord
     public string $fileName;
 
     /** @var Coordinates<CoordinateSystem12x8> */
-    public Coordinates $wellID;
+    public Coordinates $coordinates;
 
     public string $sampleDescription;
 
@@ -30,10 +30,10 @@ class CompactRegionTableRecord
 
     public string $regionComment;
 
-    /** @param Coordinates<CoordinateSystem12x8> $wellID */
+    /** @param Coordinates<CoordinateSystem12x8> $coordinates */
     public function __construct(
         string $fileName,
-        Coordinates $wellID,
+        Coordinates $coordinates,
         string $sampleDescription,
         ?int $from,
         int $to,
@@ -44,7 +44,7 @@ class CompactRegionTableRecord
         string $regionComment
     ) {
         $this->fileName = $fileName;
-        $this->wellID = $wellID;
+        $this->coordinates = $coordinates;
         $this->sampleDescription = $sampleDescription;
         $this->from = $from;
         $this->to = $to;

--- a/tests/Concentration/MolarityConverterTest.php
+++ b/tests/Concentration/MolarityConverterTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 final class MolarityConverterTest extends TestCase
 {
+    /** @dataProvider conversionPairs */
     #[DataProvider('conversionPairs')]
     public function testNgPerUlToNmolPerL(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
     {
@@ -15,6 +16,7 @@ final class MolarityConverterTest extends TestCase
         self::assertEqualsWithDelta($expectedNmolPerL, $result, 0.1);
     }
 
+    /** @dataProvider conversionPairs */
     #[DataProvider('conversionPairs')]
     public function testRoundTrip(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
     {

--- a/tests/Concentration/MolarityConverterTest.php
+++ b/tests/Concentration/MolarityConverterTest.php
@@ -25,6 +25,22 @@ final class MolarityConverterTest extends TestCase
         self::assertEqualsWithDelta($ngPerUl, $backToNgPerUl, 0.001);
     }
 
+    public function testThrowsOnZeroFragmentSize(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Fragment size must be positive');
+
+        MolarityConverter::ngPerUlToNmolPerL(10.0, 0);
+    }
+
+    public function testThrowsOnNegativeFragmentSize(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Fragment size must be positive');
+
+        MolarityConverter::nmolPerLToNgPerUl(10.0, -100);
+    }
+
     /** @return iterable<string, array{float, float, int}> */
     public static function conversionPairs(): iterable
     {

--- a/tests/Concentration/MolarityConverterTest.php
+++ b/tests/Concentration/MolarityConverterTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Tests\Concentration;
+
+use MLL\Utils\Concentration\MolarityConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MolarityConverterTest extends TestCase
+{
+    #[DataProvider('conversionPairs')]
+    public function testNgPerUlToNmolPerL(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
+    {
+        $result = MolarityConverter::ngPerUlToNmolPerL($ngPerUl, $fragmentSizeBp);
+        self::assertEqualsWithDelta($expectedNmolPerL, $result, 0.1);
+    }
+
+    #[DataProvider('conversionPairs')]
+    public function testRoundTrip(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
+    {
+        $nmolPerL = MolarityConverter::ngPerUlToNmolPerL($ngPerUl, $fragmentSizeBp);
+        $backToNgPerUl = MolarityConverter::nmolPerLToNgPerUl($nmolPerL, $fragmentSizeBp);
+        self::assertEqualsWithDelta($ngPerUl, $backToNgPerUl, 0.001);
+    }
+
+    /** @return iterable<string, array{float, float, int}> */
+    public static function conversionPairs(): iterable
+    {
+        // Values verified against TapeStation Excel pooling sheet
+        yield 'FLT3-ITD sample 11.4 ng/µl, 489 bp' => [35.3, 11.4, 489];
+        yield 'FLT3-ITD sample 9.35 ng/µl, 491 bp' => [28.9, 9.35, 491];
+        yield 'Immunoreceptor TRB 400 bp' => [37.9, 10.0, 400];
+        yield 'Immunoreceptor TRG 300 bp' => [50.5, 10.0, 300];
+        yield 'Low concentration' => [0.09, 0.03, 488];
+    }
+}

--- a/tests/Concentration/MolarityConverterTest.php
+++ b/tests/Concentration/MolarityConverterTest.php
@@ -10,9 +10,9 @@ final class MolarityConverterTest extends TestCase
 {
     /** @dataProvider conversionPairs */
     #[DataProvider('conversionPairs')]
-    public function testConcentrationToMolarity(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
+    public function testMassConcentrationToMolarity(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
     {
-        $result = MolarityConverter::concentrationToMolarity($ngPerUl, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
+        $result = MolarityConverter::massConcentrationToMolarity($ngPerUl, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
         self::assertEqualsWithDelta($expectedNmolPerL, $result, 0.1);
     }
 
@@ -20,8 +20,8 @@ final class MolarityConverterTest extends TestCase
     #[DataProvider('conversionPairs')]
     public function testRoundTrip(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
     {
-        $nmolPerL = MolarityConverter::concentrationToMolarity($ngPerUl, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
-        $backToNgPerUl = MolarityConverter::molarityToConcentration($nmolPerL, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
+        $nmolPerL = MolarityConverter::massConcentrationToMolarity($ngPerUl, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
+        $backToNgPerUl = MolarityConverter::molarityToMassConcentration($nmolPerL, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
         self::assertEqualsWithDelta($ngPerUl, $backToNgPerUl, 0.001);
     }
 
@@ -30,7 +30,7 @@ final class MolarityConverterTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Fragment size must be positive');
 
-        MolarityConverter::concentrationToMolarity(10.0, 0, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
+        MolarityConverter::massConcentrationToMolarity(10.0, 0, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
     }
 
     public function testThrowsOnNegativeFragmentSize(): void
@@ -38,7 +38,7 @@ final class MolarityConverterTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Fragment size must be positive');
 
-        MolarityConverter::molarityToConcentration(10.0, -100, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
+        MolarityConverter::molarityToMassConcentration(10.0, -100, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
     }
 
     public function testThrowsOnZeroDaltonsPerUnit(): void
@@ -46,7 +46,7 @@ final class MolarityConverterTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Daltons per unit must be positive');
 
-        MolarityConverter::concentrationToMolarity(10.0, 400, 0.0);
+        MolarityConverter::massConcentrationToMolarity(10.0, 400, 0.0);
     }
 
     /** @return iterable<string, array{float, float, int}> */

--- a/tests/Concentration/MolarityConverterTest.php
+++ b/tests/Concentration/MolarityConverterTest.php
@@ -10,9 +10,9 @@ final class MolarityConverterTest extends TestCase
 {
     /** @dataProvider conversionPairs */
     #[DataProvider('conversionPairs')]
-    public function testNgPerUlToNmolPerL(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
+    public function testConcentrationToMolarity(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
     {
-        $result = MolarityConverter::ngPerUlToNmolPerL($ngPerUl, $fragmentSizeBp);
+        $result = MolarityConverter::concentrationToMolarity($ngPerUl, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
         self::assertEqualsWithDelta($expectedNmolPerL, $result, 0.1);
     }
 
@@ -20,8 +20,8 @@ final class MolarityConverterTest extends TestCase
     #[DataProvider('conversionPairs')]
     public function testRoundTrip(float $expectedNmolPerL, float $ngPerUl, int $fragmentSizeBp): void
     {
-        $nmolPerL = MolarityConverter::ngPerUlToNmolPerL($ngPerUl, $fragmentSizeBp);
-        $backToNgPerUl = MolarityConverter::nmolPerLToNgPerUl($nmolPerL, $fragmentSizeBp);
+        $nmolPerL = MolarityConverter::concentrationToMolarity($ngPerUl, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
+        $backToNgPerUl = MolarityConverter::molarityToConcentration($nmolPerL, $fragmentSizeBp, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
         self::assertEqualsWithDelta($ngPerUl, $backToNgPerUl, 0.001);
     }
 
@@ -30,7 +30,7 @@ final class MolarityConverterTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Fragment size must be positive');
 
-        MolarityConverter::ngPerUlToNmolPerL(10.0, 0);
+        MolarityConverter::concentrationToMolarity(10.0, 0, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
     }
 
     public function testThrowsOnNegativeFragmentSize(): void
@@ -38,7 +38,15 @@ final class MolarityConverterTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Fragment size must be positive');
 
-        MolarityConverter::nmolPerLToNgPerUl(10.0, -100);
+        MolarityConverter::molarityToConcentration(10.0, -100, MolarityConverter::DALTONS_PER_BASE_PAIR_DSDNA);
+    }
+
+    public function testThrowsOnZeroDaltonsPerUnit(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Daltons per unit must be positive');
+
+        MolarityConverter::concentrationToMolarity(10.0, 400, 0.0);
     }
 
     /** @return iterable<string, array{float, float, int}> */

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -27,8 +27,8 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertSame(200, $first->from);
         self::assertSame(1000, $first->to);
         self::assertSame(505, $first->averageSize);
-        self::assertSame(15.0, $first->concentrationNgPerUl);
-        self::assertSame(46.6, $first->regionMolarityNmolPerL);
+        self::assertSame(15.0, $first->concentration);
+        self::assertSame(46.6, $first->regionMolarity);
         self::assertEqualsWithDelta(87.94, $first->percentOfTotal, 0.01);
         self::assertSame('FLT3-ITD MRD', $first->regionComment);
     }
@@ -49,8 +49,8 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertSame('A8', $record->wellID);
         self::assertSame('22-000001', $record->sampleDescription);
         self::assertSame(320, $record->averageSize);
-        self::assertSame(7.61, $record->concentrationNgPerUl);
-        self::assertSame(36.1, $record->regionMolarityNmolPerL);
+        self::assertSame(7.61, $record->concentration);
+        self::assertSame(36.1, $record->regionMolarity);
     }
 
     public function testParseWithNtUnits(): void
@@ -67,7 +67,7 @@ final class CompactRegionTableParserTest extends TestCase
         $record = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $record);
         self::assertSame(1800, $record->averageSize);
-        self::assertSame(34.7, $record->concentrationNgPerUl);
+        self::assertSame(34.7, $record->concentration);
     }
 
     public function testParseWithMuAsLatin1Byte(): void
@@ -81,7 +81,7 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertCount(1, $records);
         $record = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $record);
-        self::assertSame(12.5, $record->concentrationNgPerUl);
+        self::assertSame(12.5, $record->concentration);
     }
 
     public function testSkipsEmptyLines(): void
@@ -126,7 +126,7 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertNull($record->from);
         self::assertSame(550, $record->to);
         self::assertSame(336, $record->averageSize);
-        self::assertSame(7.61, $record->concentrationNgPerUl);
+        self::assertSame(7.61, $record->concentration);
     }
 
     public function testThrowsOnMissingConcentrationColumn(): void

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -27,8 +27,8 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertSame(200, $first->from);
         self::assertSame(1000, $first->to);
         self::assertSame(505, $first->averageSize);
-        self::assertSame(15.0, $first->concentration);
-        self::assertSame(46.6, $first->regionMolarity);
+        self::assertSame(15.0, $first->concentrationNgPerUl);
+        self::assertSame(46.6, $first->regionMolarityNmolPerL);
         self::assertEqualsWithDelta(87.94, $first->percentOfTotal, 0.01);
         self::assertSame('FLT3-ITD MRD', $first->regionComment);
     }
@@ -49,8 +49,8 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertSame('A8', $record->wellID);
         self::assertSame('22-000001', $record->sampleDescription);
         self::assertSame(320, $record->averageSize);
-        self::assertSame(7.61, $record->concentration);
-        self::assertSame(36.1, $record->regionMolarity);
+        self::assertSame(7.61, $record->concentrationNgPerUl);
+        self::assertSame(36.1, $record->regionMolarityNmolPerL);
     }
 
     public function testParseWithNtUnits(): void
@@ -67,7 +67,7 @@ final class CompactRegionTableParserTest extends TestCase
         $record = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $record);
         self::assertSame(1800, $record->averageSize);
-        self::assertSame(34.7, $record->concentration);
+        self::assertSame(34.7, $record->concentrationNgPerUl);
     }
 
     public function testParseWithMuAsLatin1Byte(): void
@@ -81,7 +81,7 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertCount(1, $records);
         $record = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $record);
-        self::assertSame(12.5, $record->concentration);
+        self::assertSame(12.5, $record->concentrationNgPerUl);
     }
 
     public function testSkipsEmptyLines(): void
@@ -126,7 +126,7 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertNull($record->from);
         self::assertSame(550, $record->to);
         self::assertSame(336, $record->averageSize);
-        self::assertSame(7.61, $record->concentration);
+        self::assertSame(7.61, $record->concentrationNgPerUl);
     }
 
     public function testThrowsOnMissingConcentrationColumn(): void

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Tests\TapeStation;
+
+use MLL\Utils\TapeStation\CompactRegionTableParser;
+use MLL\Utils\TapeStation\CompactRegionTableRecord;
+use PHPUnit\Framework\TestCase;
+
+final class CompactRegionTableParserTest extends TestCase
+{
+    public function testParseSemicolonDelimited(): void
+    {
+        $csv = <<<'CSV'
+            FileName;WellId;Sample Description;From [bp];To [bp];Average Size [bp];Conc. [ng/µl];Region Molarity [nmol/l];% of Total;Region Comment
+            2026-02-25 - 12.05.31.D1000;A1;Poko_FLT3-ITD_A1;200;1000;505;15.0;46.6;87.94;FLT3-ITD MRD
+            2026-02-25 - 12.05.31.D1000;C1;Neko_FLT3-ITD_B1;200;1000;517;13.4;40.9;83.16;FLT3-ITD MRD
+            CSV;
+
+        $records = CompactRegionTableParser::parse($csv);
+
+        self::assertCount(2, $records);
+
+        $first = $records->first();
+        self::assertInstanceOf(CompactRegionTableRecord::class, $first);
+        self::assertSame('A1', $first->wellID);
+        self::assertSame('Poko_FLT3-ITD_A1', $first->sampleDescription);
+        self::assertSame(200, $first->fromBp);
+        self::assertSame(1000, $first->toBp);
+        self::assertSame(505, $first->averageSizeBp);
+        self::assertSame(15.0, $first->concentrationNgPerUl);
+        self::assertSame(46.6, $first->regionMolarityNmolPerL);
+        self::assertEqualsWithDelta(87.94, $first->percentOfTotal, 0.01);
+        self::assertSame('FLT3-ITD MRD', $first->regionComment);
+    }
+
+    public function testParseCommaDelimited(): void
+    {
+        $csv = <<<'CSV'
+            FileName,WellId,Sample Description,From [bp],To [bp],Average Size [bp],Conc. [ng/µl],Region Molarity [nmol/l],% of Total,Region Comment
+            2026-02-25.D1000,A8,22-000001,200,700,320,7.61,36.1,92.5,IDT
+            CSV;
+
+        $records = CompactRegionTableParser::parse($csv);
+
+        self::assertCount(1, $records);
+
+        $record = $records->first();
+        self::assertInstanceOf(CompactRegionTableRecord::class, $record);
+        self::assertSame('A8', $record->wellID);
+        self::assertSame('22-000001', $record->sampleDescription);
+        self::assertSame(320, $record->averageSizeBp);
+        self::assertSame(7.61, $record->concentrationNgPerUl);
+        self::assertSame(36.1, $record->regionMolarityNmolPerL);
+    }
+
+    public function testParseWithNtUnits(): void
+    {
+        $csv = <<<'CSV'
+            FileName,WellId,Sample Description,From [nt],To [nt],Average Size [nt],Conc. [ng/µl],Region Molarity [nmol/l],% of Total,Region Comment
+            export.D1000,B2,RNA_179_23-025829_F2,200,4000,1800,34.7,29.5,85.0,WTS
+            CSV;
+
+        $records = CompactRegionTableParser::parse($csv);
+
+        self::assertCount(1, $records);
+
+        $record = $records->first();
+        self::assertInstanceOf(CompactRegionTableRecord::class, $record);
+        self::assertSame(1800, $record->averageSizeBp);
+        self::assertSame(34.7, $record->concentrationNgPerUl);
+    }
+
+    public function testParseWithCorruptedMuCharacter(): void
+    {
+        // The µ character (U+00B5) sometimes degrades to replacement character
+        $corruptedHeader = "FileName;WellId;Sample Description;From [bp];To [bp];Average Size [bp];Conc. [ng/\xC2\xB5l];Region Molarity [nmol/l];% of Total;Region Comment";
+        $csv = $corruptedHeader . "\n" . '2026-02-25.D1000;A1;Sample1;200;1000;500;12.5;38.0;90.0;MRD';
+
+        $records = CompactRegionTableParser::parse($csv);
+
+        self::assertCount(1, $records);
+        $record = $records->first();
+        self::assertInstanceOf(CompactRegionTableRecord::class, $record);
+        self::assertSame(12.5, $record->concentrationNgPerUl);
+    }
+
+    public function testSkipsEmptyLines(): void
+    {
+        $csv = <<<'CSV'
+            FileName;WellId;Sample Description;From [bp];To [bp];Average Size [bp];Conc. [ng/µl];Region Molarity [nmol/l];% of Total;Region Comment
+            2026-02-25.D1000;A1;Sample1;200;1000;500;12.5;38.0;90.0;MRD
+
+            2026-02-25.D1000;B1;Sample2;200;1000;490;8.3;25.1;85.0;MRD
+
+            CSV;
+
+        $records = CompactRegionTableParser::parse($csv);
+
+        self::assertCount(2, $records);
+    }
+
+    public function testThrowsOnMissingConcentrationColumn(): void
+    {
+        $csv = <<<'CSV'
+            FileName;WellId;Sample Description
+            2026-02-25.D1000;A1;Sample1
+            CSV;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Concentration column not found');
+
+        CompactRegionTableParser::parse($csv);
+    }
+}

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -110,6 +110,25 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertCount(0, $records);
     }
 
+    public function testParseWithMissingFromColumn(): void
+    {
+        $csv = <<<'CSV'
+            FileName,WellId,Sample Description,To [bp],Average Size [bp],Conc. [ng/µl],Region Molarity [nmol/l],% of Total,Region Comment
+            2026-02-25.D1000,A8,22-000001,550,336,7.61,36.1,80.91,IDT
+            CSV;
+
+        $records = CompactRegionTableParser::parse($csv);
+
+        self::assertCount(1, $records);
+
+        $record = $records->first();
+        self::assertInstanceOf(CompactRegionTableRecord::class, $record);
+        self::assertNull($record->from);
+        self::assertSame(550, $record->to);
+        self::assertSame(336, $record->averageSize);
+        self::assertSame(7.61, $record->concentrationNgPerUl);
+    }
+
     public function testThrowsOnMissingConcentrationColumn(): void
     {
         $csv = <<<'CSV'

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -24,9 +24,9 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertInstanceOf(CompactRegionTableRecord::class, $first);
         self::assertSame('A1', $first->wellID);
         self::assertSame('Poko_FLT3-ITD_A1', $first->sampleDescription);
-        self::assertSame(200, $first->fromBp);
-        self::assertSame(1000, $first->toBp);
-        self::assertSame(505, $first->averageSizeBp);
+        self::assertSame(200, $first->from);
+        self::assertSame(1000, $first->to);
+        self::assertSame(505, $first->averageSize);
         self::assertSame(15.0, $first->concentrationNgPerUl);
         self::assertSame(46.6, $first->regionMolarityNmolPerL);
         self::assertEqualsWithDelta(87.94, $first->percentOfTotal, 0.01);
@@ -48,7 +48,7 @@ final class CompactRegionTableParserTest extends TestCase
         self::assertInstanceOf(CompactRegionTableRecord::class, $record);
         self::assertSame('A8', $record->wellID);
         self::assertSame('22-000001', $record->sampleDescription);
-        self::assertSame(320, $record->averageSizeBp);
+        self::assertSame(320, $record->averageSize);
         self::assertSame(7.61, $record->concentrationNgPerUl);
         self::assertSame(36.1, $record->regionMolarityNmolPerL);
     }
@@ -66,15 +66,15 @@ final class CompactRegionTableParserTest extends TestCase
 
         $record = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $record);
-        self::assertSame(1800, $record->averageSizeBp);
+        self::assertSame(1800, $record->averageSize);
         self::assertSame(34.7, $record->concentrationNgPerUl);
     }
 
-    public function testParseWithCorruptedMuCharacter(): void
+    public function testParseWithMuAsLatin1Byte(): void
     {
-        // The µ character (U+00B5) sometimes degrades to replacement character
-        $corruptedHeader = "FileName;WellId;Sample Description;From [bp];To [bp];Average Size [bp];Conc. [ng/\xC2\xB5l];Region Molarity [nmol/l];% of Total;Region Comment";
-        $csv = $corruptedHeader . "\n" . '2026-02-25.D1000;A1;Sample1;200;1000;500;12.5;38.0;90.0;MRD';
+        // Latin-1 µ (0xB5) without UTF-8 prefix — occurs when files are saved as ISO-8859-1
+        $latin1Header = "FileName;WellId;Sample Description;From [bp];To [bp];Average Size [bp];Conc. [ng/\xB5l];Region Molarity [nmol/l];% of Total;Region Comment";
+        $csv = $latin1Header . "\n" . '2026-02-25.D1000;A1;Sample1;200;1000;500;12.5;38.0;90.0;MRD';
 
         $records = CompactRegionTableParser::parse($csv);
 
@@ -97,6 +97,17 @@ final class CompactRegionTableParserTest extends TestCase
         $records = CompactRegionTableParser::parse($csv);
 
         self::assertCount(2, $records);
+    }
+
+    public function testHeadersOnlyReturnsEmptyCollection(): void
+    {
+        $csv = <<<'CSV'
+            FileName;WellId;Sample Description;From [bp];To [bp];Average Size [bp];Conc. [ng/µl];Region Molarity [nmol/l];% of Total;Region Comment
+            CSV;
+
+        $records = CompactRegionTableParser::parse($csv);
+
+        self::assertCount(0, $records);
     }
 
     public function testThrowsOnMissingConcentrationColumn(): void

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -141,4 +141,30 @@ final class CompactRegionTableParserTest extends TestCase
 
         CompactRegionTableParser::parse($csv);
     }
+
+    public function testThrowsOnHighSensitivityConcentration(): void
+    {
+        $csv = <<<'CSV'
+            FileName,WellId,Sample Description,From [bp],To [bp],Average Size [bp],Conc. [pg/µl],Region Molarity [nmol/l],% of Total,Region Comment
+            2026-02-25.HSD1000,A1,Sample1,200,1000,500,125.0,38.0,90.0,MRD
+            CSV;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('High Sensitivity assay detected (pg/µl)');
+
+        CompactRegionTableParser::parse($csv);
+    }
+
+    public function testThrowsOnHighSensitivityMolarity(): void
+    {
+        $csv = <<<'CSV'
+            FileName,WellId,Sample Description,From [bp],To [bp],Average Size [bp],Conc. [ng/µl],Region Molarity [pmol/l],% of Total,Region Comment
+            2026-02-25.HSD1000,A1,Sample1,200,1000,500,12.5,38000.0,90.0,MRD
+            CSV;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('High Sensitivity assay detected (pmol/l)');
+
+        CompactRegionTableParser::parse($csv);
+    }
 }

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -22,7 +22,7 @@ final class CompactRegionTableParserTest extends TestCase
 
         $first = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $first);
-        self::assertSame('A1', $first->wellID);
+        self::assertSame('A1', $first->wellID->toString());
         self::assertSame('Poko_FLT3-ITD_A1', $first->sampleDescription);
         self::assertSame(200, $first->from);
         self::assertSame(1000, $first->to);
@@ -46,7 +46,7 @@ final class CompactRegionTableParserTest extends TestCase
 
         $record = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $record);
-        self::assertSame('A8', $record->wellID);
+        self::assertSame('A8', $record->wellID->toString());
         self::assertSame('22-000001', $record->sampleDescription);
         self::assertSame(320, $record->averageSize);
         self::assertSame(7.61, $record->concentrationNgPerUl);

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -22,7 +22,7 @@ final class CompactRegionTableParserTest extends TestCase
 
         $first = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $first);
-        self::assertSame('A1', $first->wellID->toString());
+        self::assertSame('A1', $first->coordinates->toString());
         self::assertSame('Poko_FLT3-ITD_A1', $first->sampleDescription);
         self::assertSame(200, $first->from);
         self::assertSame(1000, $first->to);
@@ -46,7 +46,7 @@ final class CompactRegionTableParserTest extends TestCase
 
         $record = $records->first();
         self::assertInstanceOf(CompactRegionTableRecord::class, $record);
-        self::assertSame('A8', $record->wellID->toString());
+        self::assertSame('A8', $record->coordinates->toString());
         self::assertSame('22-000001', $record->sampleDescription);
         self::assertSame(320, $record->averageSize);
         self::assertSame(7.61, $record->concentrationNgPerUl);

--- a/tests/TapeStation/CompactRegionTableParserTest.php
+++ b/tests/TapeStation/CompactRegionTableParserTest.php
@@ -132,8 +132,8 @@ final class CompactRegionTableParserTest extends TestCase
     public function testThrowsOnMissingConcentrationColumn(): void
     {
         $csv = <<<'CSV'
-            FileName;WellId;Sample Description
-            2026-02-25.D1000;A1;Sample1
+            FileName;WellId;Sample Description;From [bp];To [bp];Average Size [bp];Region Molarity [nmol/l];% of Total;Region Comment
+            2026-02-25.D1000;A1;Sample1;200;1000;500;38.0;90.0;MRD
             CSV;
 
         $this->expectException(\RuntimeException::class);


### PR DESCRIPTION
## Summary

- Add `MolarityConverter` for converting between mass concentration (ng/µL) and molar concentration (nmol/L) for dsDNA fragments
- Add `CompactRegionTableParser` to parse Agilent TapeStation "Compact Region Table" CSV exports with delimiter detection and µ-encoding resilience
- Add `CompactRegionTableRecord` as value object for parsed records
- Defensive rejection of High Sensitivity assays (pg/µl + pmol/l) — prevents silent 1000× unit errors
- `$from` is nullable for exports where the "From" column is absent
- PHPDoc aligned with the official Agilent 4200 TapeStation System Manual

## Test plan

- [x] 10 tests covering semicolon/comma delimiters, bp/nt units, Latin-1 µ encoding, missing From column, HS assay rejection
- [x] 6 tests for MolarityConverter
- [x] PHPStan level max passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)