### PR TITLE
fix(phpstan): resolve preg_match offset access errors

### DIFF
--- a/src/Chromosome.php
+++ b/src/Chromosome.php
@@ -20,7 +20,9 @@ class Chromosome
 
         assert(isset($matches[1]));
         $value = strtoupper($matches[1]);
-        $this->value = $value === self::MITOCHONDRIAL_ENSEMBL ? self::MITOCHONDRIAL : $value;
+        $this->value = $value === self::MITOCHONDRIAL_ENSEMBL
+            ? self::MITOCHONDRIAL
+            : $value;
     }
 
     public function value(): string

--- a/src/Chromosome.php
+++ b/src/Chromosome.php
@@ -14,11 +14,12 @@ class Chromosome
     public function __construct(string $value)
     {
         /** Matches human chromosomes with or without "chr" prefix: chr1-chr22, chrX, chrY, chrM, chrMT, or 1-22, X, Y, M, MT. */
-        if (preg_match('/^(chr)?(1[0-9]|[1-9]|2[0-2]|X|Y|M|MT)$/i', $value, $matches) === 0) {
+        if (preg_match('/^(?:chr)?(1[0-9]|[1-9]|2[0-2]|X|Y|M|MT)$/i', $value, $matches) === 0) {
             throw new \InvalidArgumentException("Invalid chromosome: {$value}. Expected format: chr1-chr22, chrX, chrY, chrM, or without chr prefix.");
         }
 
-        $value = strtoupper($matches[2]);
+        assert(isset($matches[1]));
+        $value = strtoupper($matches[1]);
         $this->value = $value === self::MITOCHONDRIAL_ENSEMBL ? self::MITOCHONDRIAL : $value;
     }
 

--- a/src/GenomicPosition.php
+++ b/src/GenomicPosition.php
@@ -19,11 +19,13 @@ class GenomicPosition
     /** @example GenomicPosition::parseOneBased('chr1:123456') */
     public static function parseOneBased(string $value): self
     {
-        if (preg_match('/^([^:]+):(g\.|)(\d+)$/', $value, $matches) === 0) {
+        if (preg_match('/^([^:]+):(?:g\.)?(\d+)$/', $value, $matches) === 0) {
             throw new \InvalidArgumentException("Invalid genomic position format: {$value}. Expected format: chr1:123456.");
         }
 
-        return new self(new Chromosome($matches[1]), NucleotidePosition::fromOneBased((int) $matches[3]));
+        assert(isset($matches[1], $matches[2]));
+
+        return new self(new Chromosome($matches[1]), NucleotidePosition::fromOneBased(SafeCast::toInt($matches[2])));
     }
 
     public function equals(self $other): bool

--- a/src/GenomicRegion.php
+++ b/src/GenomicRegion.php
@@ -28,14 +28,16 @@ class GenomicRegion
 
     public static function parseOneBased(string $value): self
     {
-        if (preg_match('/^([^:]+):(g\.|)(\d+)(-(\d+)|)$/', $value, $matches) === 0) {
+        if (preg_match('/^([^:]+):(?:g\.)?(\d+)(?:-(\d+))?$/', $value, $matches) === 0) {
             throw new \InvalidArgumentException("Invalid genomic region format: {$value}. Expected format: chr1:123-456.");
         }
 
+        assert(isset($matches[1], $matches[2]));
+
         return new self(
             new Chromosome($matches[1]),
-            NucleotidePosition::fromOneBased((int) $matches[3]),
-            NucleotidePosition::fromOneBased((int) ($matches[5] ?? $matches[3]))
+            NucleotidePosition::fromOneBased(SafeCast::toInt($matches[2])),
+            NucleotidePosition::fromOneBased(SafeCast::toInt($matches[3] ?? $matches[2]))
         );
     }
 

--- a/src/IlluminaRunFolder.php
+++ b/src/IlluminaRunFolder.php
@@ -94,10 +94,14 @@ class IlluminaRunFolder
     private static function extractFlowcellID(string $flowcellSegment): string
     {
         if (preg_match(self::ZERO_PREFIXED_PATTERN, $flowcellSegment, $matches) === 1) {
+            assert(isset($matches[1]));
+
             return $matches[1];
         }
 
         if (preg_match(self::SIDE_PREFIXED_PATTERN, $flowcellSegment, $matches) === 1) {
+            assert(isset($matches[1]));
+
             return $matches[1];
         }
 


### PR DESCRIPTION
## Summary

- Use non-capturing groups (`(?:...)`) for regex captures that are never referenced, reducing match array indices
- Add `assert(isset(...))` for remaining match offsets so PHPStan can verify safe array access
- Use `SafeCast::toInt()` instead of `(int)` casts for regex match conversions
- Use `NucleotidePosition::fromOneBased()` consistent with master
- Fixes all 8 `offsetAccess.notFound` errors across `Chromosome`, `GenomicPosition`, `GenomicRegion`, and `IlluminaRunFolder`

## Test plan

- [x] `make stan` passes with 0 errors
- [x] `make test` passes (673 tests, 3887 assertions)

🤖 Generated with Claude Code