### PR TITLE
ci: add explicit permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Align with js-utils, eslint-config, and other mll-lab repos that
already declare workflow permissions for semantic-release.

🤖 Generated with Claude Code
