### PR TITLE
fix: replace Codecov upload with GitHub Job Summary for coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        only_pulls: true
-comment: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -127,4 +127,4 @@ jobs:
 
       - uses: ramsey/composer-install@v3
 
-      - run: vendor/bin/phpunit --coverage-text | tee $GITHUB_STEP_SUMMARY
+      - run: vendor/bin/phpunit --coverage-text --colors=never | tee $GITHUB_STEP_SUMMARY

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -127,4 +127,10 @@ jobs:
 
       - uses: ramsey/composer-install@v3
 
-      - run: vendor/bin/phpunit --coverage-text --colors=never | tee $GITHUB_STEP_SUMMARY
+      - run: |
+          {
+            echo '## Code Coverage'
+            echo '```'
+            vendor/bin/phpunit --coverage-text --colors=never
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -116,6 +116,10 @@ jobs:
   code-coverage:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      code-quality: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -127,10 +131,10 @@ jobs:
 
       - uses: ramsey/composer-install@v3
 
-      - run: |
-          {
-            echo '## Code Coverage'
-            echo '```'
-            vendor/bin/phpunit --coverage-text --colors=never
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+      - run: vendor/bin/phpunit --coverage-clover=coverage.xml
+
+      - if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage.xml
+          language: PHP

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -127,7 +127,4 @@ jobs:
 
       - uses: ramsey/composer-install@v3
 
-      - run: vendor/bin/phpunit --coverage-clover=.build/logs/clover.xml
-
-      # Not using v4 due to the breaking changes described in https://github.com/codecov/codecov-action/releases/tag/v4.0.0
-      - uses: codecov/codecov-action@v3
+      - run: vendor/bin/phpunit --coverage-text | tee $GITHUB_STEP_SUMMARY

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -131,10 +131,11 @@ jobs:
 
       - uses: ramsey/composer-install@v3
 
-      - run: vendor/bin/phpunit --coverage-clover=coverage.xml
+      - run: vendor/bin/phpunit --coverage-cobertura=coverage.xml
 
       - if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-code-coverage@v1
         with:
           file: coverage.xml
           language: PHP
+          label: code-coverage/phpunit


### PR DESCRIPTION
Codecov uploads without a token hit a global rate limit (HTTP 429),
causing intermittent CI failures unrelated to the actual test results.
Closes https://github.com/mll-lab/php-utils/issues/44

Switch to `actions/upload-code-coverage@v1` — GitHub's native code quality
feature. PHPUnit generates a Cobertura XML report, which is uploaded to
GitHub's coverage API. The `github-code-quality[bot]` then posts per-file
coverage breakdowns directly on each PR.

Remove `.codecov.yml` — no longer needed.