### PR TITLE
fix: ignore security advisories for legacy laravel/framework versions in dev matrix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
       ],
       "abandoned": "ignore"
     },
+    "block-insecure": false,
     "policy": {
       "advisories": {
         "ignore": [
@@ -77,7 +78,6 @@
         ]
       }
     },
-    "block-insecure": false,
     "sort-packages": true
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,13 @@
       ],
       "abandoned": "ignore"
     },
+    "policy": {
+      "advisories": {
+        "ignore": [
+          "laravel/framework"
+        ]
+      }
+    },
     "block-insecure": false,
     "sort-packages": true
   },

--- a/tests/Microplate/CoordinateSystemTest.php
+++ b/tests/Microplate/CoordinateSystemTest.php
@@ -63,11 +63,11 @@ final class CoordinateSystemTest extends TestCase
         self::assertTrue($coordinateSystem6x8->equals($coordinateSystem6x8AnotherInstance));
         self::assertTrue($coordinateSystem6x8AnotherInstance->equals($coordinateSystem6x8));
 
-        $coordinateSystem6x8Child = new class() extends CoordinateSystem6x8 {};
+        $coordinateSystem6x8Child = new class extends CoordinateSystem6x8 {};
         self::assertTrue($coordinateSystem6x8->equals($coordinateSystem6x8Child));
         self::assertTrue($coordinateSystem6x8Child->equals($coordinateSystem6x8));
 
-        $coordinateSystem8x8ModifiedChild = new class() extends CoordinateSystem6x8 {
+        $coordinateSystem8x8ModifiedChild = new class extends CoordinateSystem6x8 {
             public function columns(): array
             {
                 return range(1, 8);

--- a/tests/SafeCastTest.php
+++ b/tests/SafeCastTest.php
@@ -149,13 +149,13 @@ final class SafeCastTest extends TestCase
         yield ['0', 0];
         yield ['3.14', 3.14];
         yield ['-2.5', -2.5];
-        yield ['object-string-with-stringable-interface', new class() implements \Stringable {
+        yield ['object-string-with-stringable-interface', new class implements \Stringable {
             public function __toString(): string
             {
                 return 'object-string-with-stringable-interface';
             }
         }];
-        yield ['object-string-without-stringable-interface', new class() {
+        yield ['object-string-without-stringable-interface', new class {
             public function __toString(): string
             {
                 return 'object-string-without-stringable-interface';


### PR DESCRIPTION
## Summary

Legacy PHP versions (7.4, 8.0, 8.1) can only install older `laravel/framework` versions that carry known security advisories. Since this is a dev-only dependency pulled in via `orchestra/testbench`, blocking on these advisories prevents CI from running on the supported PHP version range without any practical security impact.

Adds `config.policy.advisories.ignore` for `laravel/framework` to tell Composer 2.10+ to skip advisory blocking for this package.

🤖 Generated with Claude Code