### PR TITLE
fix(interop): round yield before casting to int

### DIFF
--- a/src/InterOp/LaneResult.php
+++ b/src/InterOp/LaneResult.php
@@ -88,7 +88,8 @@ class LaneResult
             $clusterStatistic,
             $sequencingQualityControl,
             SafeCast::toInt($intensityCycle->value),
-            SafeCast::toInt(SafeCast::toFloat($row['Yield']) * 1000000)
+            // Rounding because float multiplication is inexact, e.g. 8.04 * 1000000 = 8039999.999999999
+            SafeCast::toInt(round(SafeCast::toFloat($row['Yield']) * 1000000))
         );
     }
 

--- a/tests/InterOp/LaneResultTest.php
+++ b/tests/InterOp/LaneResultTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Tests\InterOp;
+
+use MLL\Utils\InterOp\LaneResult;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class LaneResultTest extends TestCase
+{
+    /** @dataProvider yieldsProvider */
+    #[DataProvider('yieldsProvider')]
+    public function testConvertsYieldToKilobases(string $gigabases, int $expectedKilobases): void
+    {
+        $laneResult = LaneResult::fromInterOpRow([
+            'Density' => '1234 +/- 56',
+            'Cluster PF' => '92.34 +/- 1.23',
+            'Aligned' => '28.66 +/- 0.12',
+            'Error' => '0.27 +/- 0.01',
+            'Intensity C1' => '4321 +/- 0',
+            'Legacy Phasing/Prephasing Rate' => '0.123 / 0.045',
+            'Reads' => '1.23',
+            'Reads PF' => '1.13',
+            '%>=Q30' => '93.21',
+            'Yield' => $gigabases,
+        ]);
+
+        self::assertSame($expectedKilobases, $laneResult->yield);
+    }
+
+    /** @return iterable<array{string, int}> */
+    public static function yieldsProvider(): iterable
+    {
+        yield ['8.04', 8040000];
+        yield ['1.49', 1490000];
+        yield ['0.02', 20000];
+        yield ['0', 0];
+    }
+}

--- a/tests/Microplate/CoordinateSystemTest.php
+++ b/tests/Microplate/CoordinateSystemTest.php
@@ -63,11 +63,11 @@ final class CoordinateSystemTest extends TestCase
         self::assertTrue($coordinateSystem6x8->equals($coordinateSystem6x8AnotherInstance));
         self::assertTrue($coordinateSystem6x8AnotherInstance->equals($coordinateSystem6x8));
 
-        $coordinateSystem6x8Child = new class() extends CoordinateSystem6x8 {};
+        $coordinateSystem6x8Child = new class extends CoordinateSystem6x8 {};
         self::assertTrue($coordinateSystem6x8->equals($coordinateSystem6x8Child));
         self::assertTrue($coordinateSystem6x8Child->equals($coordinateSystem6x8));
 
-        $coordinateSystem8x8ModifiedChild = new class() extends CoordinateSystem6x8 {
+        $coordinateSystem8x8ModifiedChild = new class extends CoordinateSystem6x8 {
             public function columns(): array
             {
                 return range(1, 8);

--- a/tests/SafeCastTest.php
+++ b/tests/SafeCastTest.php
@@ -149,13 +149,13 @@ final class SafeCastTest extends TestCase
         yield ['0', 0];
         yield ['3.14', 3.14];
         yield ['-2.5', -2.5];
-        yield ['object-string-with-stringable-interface', new class() implements \Stringable {
+        yield ['object-string-with-stringable-interface', new class implements \Stringable {
             public function __toString(): string
             {
                 return 'object-string-with-stringable-interface';
             }
         }];
-        yield ['object-string-without-stringable-interface', new class() {
+        yield ['object-string-without-stringable-interface', new class {
             public function __toString(): string
             {
                 return 'object-string-without-stringable-interface';


### PR DESCRIPTION
Float multiplication is inexact: 8.04 * 1000000 yields 8039999.999999999, which SafeCast::toInt rejects as not a whole number.

- [x] Added automated tests
- [x] Documented for all relevant versions

<!-- Resolves #ISSUE -->

**Changes**

<!-- Detail the changes in behavior this PR introduces. -->

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
