### PR TITLE
feat(phpstan): add MissingClosureReturnTypehintRule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -59,6 +59,10 @@ This library ships custom PHPStan rules (`src/PHPStan/Rules/`) and disallowed ca
 Consumer projects get these automatically via `phpstan/extension-installer`.
 
 The `phpstan.neon` in this repo includes additional rules enabled only for this project itself.
+A rule enabled there needs an `ignoreErrors` entry scoped to `tests/PHPStan/data/`, since fixtures violate rules on purpose.
+
+Test new rules with PHPStan's `RuleTestCase` against a fixture in `tests/PHPStan/data/`.
+That directory is excluded from rector and php-cs-fixer — both would otherwise normalize away the violations under test.
 
 ## Conventions
 

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,6 +4,8 @@ use function MLL\PhpCsFixerConfig\risky;
 
 $finder = PhpCsFixer\Finder::create()
     ->notPath('vendor')
+    // Fixtures intentionally violate the rules under test
+    ->exclude('tests/PHPStan/data')
     ->in(__DIR__)
     ->name('*.php')
     ->ignoreDotFiles(true)

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,8 +4,7 @@ use function MLL\PhpCsFixerConfig\risky;
 
 $finder = PhpCsFixer\Finder::create()
     ->notPath('vendor')
-    // Fixtures intentionally violate the rules under test
-    ->exclude('tests/PHPStan/data')
+    ->exclude('tests/PHPStan/data') // Fixtures intentionally violate the rules under test
     ->in(__DIR__)
     ->name('*.php')
     ->ignoreDotFiles(true)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -45,6 +45,14 @@ parameters:
     paths:
     - tests/PHPStan/data/
 
+  # Test fixtures include untyped functions and methods to prove the closure rules ignore them
+  - message: '#has no return type specified\.#'
+    paths:
+    - tests/PHPStan/data/
+  - message: '#with no type specified\.#'
+    paths:
+    - tests/PHPStan/data/
+
   # PHPStan internal API usage is acceptable in tests
   - message: '#is not covered by backward compatibility promise#'
     paths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ rules:
 #- MLL\Utils\PHPStan\Rules\ThrowableClassNameRule
 - MLL\Utils\PHPStan\Rules\VariableNameIdToIDRule
 - MLL\Utils\PHPStan\Rules\MissingClosureParameterTypehintRule
+- MLL\Utils\PHPStan\Rules\MissingClosureReturnTypehintRule
 parameters:
   level: max
   paths:
@@ -33,6 +34,11 @@ parameters:
 
   # Test fixtures intentionally contain ID capitalization violations
   - message: '#should use "ID" instead of "Id"#'
+    paths:
+    - tests/PHPStan/data/
+
+  # Test fixtures intentionally omit closure return type hints
+  - message: '#is missing a native return type hint\.#'
     paths:
     - tests/PHPStan/data/
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -37,8 +37,11 @@ parameters:
     paths:
     - tests/PHPStan/data/
 
-  # Test fixtures intentionally omit closure return type hints
+  # Test fixtures intentionally omit closure type hints
   - message: '#is missing a native return type hint\.#'
+    paths:
+    - tests/PHPStan/data/
+  - message: '#is missing a native type hint\.#'
     paths:
     - tests/PHPStan/data/
 

--- a/phpstan/php-below-8.1.neon
+++ b/phpstan/php-below-8.1.neon
@@ -4,7 +4,7 @@ parameters:
     - '#Unknown PHPDoc tag: @phpstan-ignore#'
 
     # Older PHPStan has stricter/different closure parameter typehint checking
-    - '#Closure parameter .* is missing a native type hint\.#'
+    - '#(Closure|Arrow function) parameter .* is missing a native type hint\.#'
 
     # Differences in type inference between PHPStan versions
     - '#Cannot access property .* on mixed\.#'
@@ -29,7 +29,7 @@ parameters:
     - '#PHPDoc tag @param has invalid value.*covariant.*#'
 
     # Return type differences in older PHPStan rule interfaces
-    - '#Method MLL\\Utils\\PHPStan\\Rules\\MissingClosureParameterTypehintRule::processNode\(\) should return array<int, PHPStan\\Rules\\IdentifierRuleError> but returns array<int, PHPStan\\Rules\\RuleError>\.#'
+    - '#Method MLL\\Utils\\PHPStan\\Rules\\MissingClosure(Parameter|Return)TypehintRule::processClosure\(\) should return array<int, PHPStan\\Rules\\IdentifierRuleError> but returns array<int, PHPStan\\Rules\\RuleError>\.#'
 
     # Existing code with @phpstan-ignore that older versions don't understand
     - message: '#Cannot access property \$name on SimpleXMLElement\|null\.#'

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return RectorConfig::configure()
         Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector::class,
     ])
     ->withSkip([
+        __DIR__ . '/tests/PHPStan/data', // fixtures intentionally violate the rules under test
         Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class, // breaks tests
         Rector\CodeQuality\Rector\Concat\JoinStringConcatRector::class => [
             __DIR__ . '/tests/CSVArrayTest.php', // keep `\r\n` for readability

--- a/rules.neon
+++ b/rules.neon
@@ -4,6 +4,7 @@ rules:
 #- MLL\Utils\PHPStan\Rules\VariableNameIdToIDRule
 #- MLL\Utils\PHPStan\Rules\PropertyNameIdToIDRule
 #- MLL\Utils\PHPStan\Rules\MissingClosureParameterTypehintRule
+#- MLL\Utils\PHPStan\Rules\MissingClosureReturnTypehintRule
 parameters:
   # https://github.com/spaze/phpstan-disallowed-calls/blob/main/docs/custom-rules.md
   disallowedFunctionCalls:

--- a/src/PHPStan/Rules/ClosureTypehintRule.php
+++ b/src/PHPStan/Rules/ClosureTypehintRule.php
@@ -21,6 +21,14 @@ abstract class ClosureTypehintRule implements Rule
      */
     abstract protected function processClosure(Node\FunctionLike $closure): array;
 
+    /** @param Closure|ArrowFunction $closure */
+    protected function closureKind(Node\FunctionLike $closure): string
+    {
+        return $closure instanceof ArrowFunction
+            ? 'Arrow function'
+            : 'Closure';
+    }
+
     /** @return class-string<Node\FunctionLike> */
     public function getNodeType(): string
     {

--- a/src/PHPStan/Rules/ClosureTypehintRule.php
+++ b/src/PHPStan/Rules/ClosureTypehintRule.php
@@ -10,7 +10,7 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 
 /**
- * @implements Rule<Node\Expr>
+ * @implements Rule<Node\FunctionLike>
  */
 abstract class ClosureTypehintRule implements Rule
 {
@@ -21,14 +21,14 @@ abstract class ClosureTypehintRule implements Rule
      */
     abstract protected function processClosure(Node\FunctionLike $closure): array;
 
-    /** @return class-string<Node\Expr> */
+    /** @return class-string<Node\FunctionLike> */
     public function getNodeType(): string
     {
-        return Node\Expr::class;
+        return Node\FunctionLike::class;
     }
 
     /**
-     * @param Node\Expr $node
+     * @param Node\FunctionLike $node
      *
      * @return list<IdentifierRuleError>
      */

--- a/src/PHPStan/Rules/ClosureTypehintRule.php
+++ b/src/PHPStan/Rules/ClosureTypehintRule.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<Node\Expr>
+ */
+abstract class ClosureTypehintRule implements Rule
+{
+    /**
+     * @param Closure|ArrowFunction $closure
+     *
+     * @return list<IdentifierRuleError>
+     */
+    abstract protected function processClosure(Node\FunctionLike $closure): array;
+
+    /** @return class-string<Node\Expr> */
+    public function getNodeType(): string
+    {
+        return Node\Expr::class;
+    }
+
+    /**
+     * @param Node\Expr $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node instanceof Closure && ! $node instanceof ArrowFunction) {
+            return [];
+        }
+
+        return $this->processClosure($node);
+    }
+}

--- a/src/PHPStan/Rules/MissingClosureParameterTypehintRule.php
+++ b/src/PHPStan/Rules/MissingClosureParameterTypehintRule.php
@@ -32,6 +32,7 @@ final class MissingClosureParameterTypehintRule extends ClosureTypehintRule
 
             $errors[] = RuleErrorBuilder::message("{$kind} parameter {$varName} is missing a native type hint.")
                 ->identifier('missingType.parameter')
+                ->line($param->getStartLine())
                 ->build();
         }
 

--- a/src/PHPStan/Rules/MissingClosureParameterTypehintRule.php
+++ b/src/PHPStan/Rules/MissingClosureParameterTypehintRule.php
@@ -10,6 +10,8 @@ final class MissingClosureParameterTypehintRule extends ClosureTypehintRule
 {
     protected function processClosure(Node\FunctionLike $closure): array
     {
+        $kind = $this->closureKind($closure);
+
         $errors = [];
         foreach ($closure->getParams() as $param) {
             if ($param->type !== null) {
@@ -28,7 +30,7 @@ final class MissingClosureParameterTypehintRule extends ClosureTypehintRule
 
             $varName = $paramVar->name;
 
-            $errors[] = RuleErrorBuilder::message("Closure parameter {$varName} is missing a native type hint.")
+            $errors[] = RuleErrorBuilder::message("{$kind} parameter {$varName} is missing a native type hint.")
                 ->identifier('missingType.parameter')
                 ->build();
         }

--- a/src/PHPStan/Rules/MissingClosureParameterTypehintRule.php
+++ b/src/PHPStan/Rules/MissingClosureParameterTypehintRule.php
@@ -24,11 +24,11 @@ final class MissingClosureParameterTypehintRule extends ClosureTypehintRule
                 continue;
             }
 
-            if (! is_string($paramVar->name)) {
+            $varName = $paramVar->name;
+
+            if (! is_string($varName)) {
                 continue;
             }
-
-            $varName = $paramVar->name;
 
             $errors[] = RuleErrorBuilder::message("{$kind} parameter {$varName} is missing a native type hint.")
                 ->identifier('missingType.parameter')

--- a/src/PHPStan/Rules/MissingClosureParameterTypehintRule.php
+++ b/src/PHPStan/Rules/MissingClosureParameterTypehintRule.php
@@ -3,38 +3,15 @@
 namespace MLL\Utils\PHPStan\Rules;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
-use PHPStan\Analyser\Scope;
-use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
-/**
- * @implements Rule<Node\Expr>
- */
-final class MissingClosureParameterTypehintRule implements Rule
+final class MissingClosureParameterTypehintRule extends ClosureTypehintRule
 {
-    /** @return class-string<Node\Expr> */
-    public function getNodeType(): string
+    protected function processClosure(Node\FunctionLike $closure): array
     {
-        return Node\Expr::class;
-    }
-
-    /**
-     * @param Node\Expr $node
-     *
-     * @return list<IdentifierRuleError>
-     */
-    public function processNode(Node $node, Scope $scope): array
-    {
-        if (! $node instanceof Closure && ! $node instanceof ArrowFunction) {
-            return [];
-        }
-
         $errors = [];
-        foreach ($node->params as $param) {
+        foreach ($closure->getParams() as $param) {
             if ($param->type !== null) {
                 continue;
             }

--- a/src/PHPStan/Rules/MissingClosureReturnTypehintRule.php
+++ b/src/PHPStan/Rules/MissingClosureReturnTypehintRule.php
@@ -3,9 +3,13 @@
 namespace MLL\Utils\PHPStan\Rules;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\ArrowFunction;
 use PHPStan\Rules\RuleErrorBuilder;
 
+/**
+ * Assumes PHP 8.0+, where every return type is natively expressible.
+ * On PHP 7.4 a closure returning `mixed` has no native type to declare,
+ * which is why `phpstan/include-by-php-version.php` gates `rules.neon`.
+ */
 final class MissingClosureReturnTypehintRule extends ClosureTypehintRule
 {
     protected function processClosure(Node\FunctionLike $closure): array
@@ -14,7 +18,7 @@ final class MissingClosureReturnTypehintRule extends ClosureTypehintRule
             return [];
         }
 
-        $kind = $closure instanceof ArrowFunction ? 'Arrow function' : 'Closure';
+        $kind = $this->closureKind($closure);
 
         return [
             RuleErrorBuilder::message("{$kind} is missing a native return type hint.")

--- a/src/PHPStan/Rules/MissingClosureReturnTypehintRule.php
+++ b/src/PHPStan/Rules/MissingClosureReturnTypehintRule.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Node\Expr>
+ */
+final class MissingClosureReturnTypehintRule implements Rule
+{
+    /** @return class-string<Node\Expr> */
+    public function getNodeType(): string
+    {
+        return Node\Expr::class;
+    }
+
+    /**
+     * @param Node\Expr $node
+     *
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node instanceof Closure && ! $node instanceof ArrowFunction) {
+            return [];
+        }
+
+        if ($node->returnType instanceof Node) {
+            return [];
+        }
+
+        $kind = $node instanceof ArrowFunction ? 'Arrow function' : 'Closure';
+
+        return [
+            RuleErrorBuilder::message("{$kind} is missing a native return type hint.")
+                ->identifier('missingType.closureReturn')
+                ->build(),
+        ];
+    }
+}

--- a/src/PHPStan/Rules/MissingClosureReturnTypehintRule.php
+++ b/src/PHPStan/Rules/MissingClosureReturnTypehintRule.php
@@ -4,39 +4,17 @@ namespace MLL\Utils\PHPStan\Rules;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Closure;
-use PHPStan\Analyser\Scope;
-use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
-/**
- * @implements Rule<Node\Expr>
- */
-final class MissingClosureReturnTypehintRule implements Rule
+final class MissingClosureReturnTypehintRule extends ClosureTypehintRule
 {
-    /** @return class-string<Node\Expr> */
-    public function getNodeType(): string
+    protected function processClosure(Node\FunctionLike $closure): array
     {
-        return Node\Expr::class;
-    }
-
-    /**
-     * @param Node\Expr $node
-     *
-     * @return list<IdentifierRuleError>
-     */
-    public function processNode(Node $node, Scope $scope): array
-    {
-        if (! $node instanceof Closure && ! $node instanceof ArrowFunction) {
+        if ($closure->getReturnType() instanceof Node) {
             return [];
         }
 
-        if ($node->returnType instanceof Node) {
-            return [];
-        }
-
-        $kind = $node instanceof ArrowFunction ? 'Arrow function' : 'Closure';
+        $kind = $closure instanceof ArrowFunction ? 'Arrow function' : 'Closure';
 
         return [
             RuleErrorBuilder::message("{$kind} is missing a native return type hint.")

--- a/tests/PHPStan/MissingClosureParameterTypehintRuleTest.php
+++ b/tests/PHPStan/MissingClosureParameterTypehintRuleTest.php
@@ -20,7 +20,7 @@ final class MissingClosureParameterTypehintRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__ . '/data/closure-parameter-types.php'], [
             ['Closure parameter factor is missing a native type hint.', 3],
-            ['Closure parameter factor is missing a native type hint.', 7],
+            ['Arrow function parameter factor is missing a native type hint.', 7],
         ]);
     }
 }

--- a/tests/PHPStan/MissingClosureParameterTypehintRuleTest.php
+++ b/tests/PHPStan/MissingClosureParameterTypehintRuleTest.php
@@ -21,6 +21,8 @@ final class MissingClosureParameterTypehintRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/closure-parameter-types.php'], [
             ['Closure parameter factor is missing a native type hint.', 3],
             ['Arrow function parameter factor is missing a native type hint.', 7],
+            ['Closure parameter first is missing a native type hint.', 16],
+            ['Closure parameter second is missing a native type hint.', 17],
         ]);
     }
 }

--- a/tests/PHPStan/MissingClosureParameterTypehintRuleTest.php
+++ b/tests/PHPStan/MissingClosureParameterTypehintRuleTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Tests\PHPStan;
+
+use MLL\Utils\PHPStan\Rules\MissingClosureParameterTypehintRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<MissingClosureParameterTypehintRule>
+ */
+final class MissingClosureParameterTypehintRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new MissingClosureParameterTypehintRule();
+    }
+
+    public function testMissingParameterTypes(): void
+    {
+        $this->analyse([__DIR__ . '/data/closure-parameter-types.php'], [
+            ['Closure parameter factor is missing a native type hint.', 3],
+            ['Closure parameter factor is missing a native type hint.', 7],
+        ]);
+    }
+}

--- a/tests/PHPStan/MissingClosureReturnTypehintRuleTest.php
+++ b/tests/PHPStan/MissingClosureReturnTypehintRuleTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace MLL\Utils\Tests\PHPStan;
+
+use MLL\Utils\PHPStan\Rules\MissingClosureReturnTypehintRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<MissingClosureReturnTypehintRule>
+ */
+final class MissingClosureReturnTypehintRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new MissingClosureReturnTypehintRule();
+    }
+
+    public function testMissingReturnTypes(): void
+    {
+        $this->analyse([__DIR__ . '/data/closure-return-types.php'], [
+            ['Closure is missing a native return type hint.', 3],
+            ['Arrow function is missing a native return type hint.', 7],
+        ]);
+    }
+}

--- a/tests/PHPStan/data/closure-parameter-types.php
+++ b/tests/PHPStan/data/closure-parameter-types.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+$missingClosureParameter = static function ($factor): int {
+    return 2;
+};
+
+$missingArrowParameter = static fn ($factor): int => 2;
+
+$typedClosureParameter = static function (int $factor): int {
+    return 2 * $factor;
+};
+
+$typedArrowParameter = static fn (int $factor): int => 2 * $factor;

--- a/tests/PHPStan/data/closure-parameter-types.php
+++ b/tests/PHPStan/data/closure-parameter-types.php
@@ -12,6 +12,13 @@ $typedClosureParameter = static function (int $factor): int {
 
 $typedArrowParameter = static fn (int $factor): int => 2 * $factor;
 
+$missingMultiLineParameters = static function (
+    $first,
+    $second
+): int {
+    return 2;
+};
+
 // Only closures are in scope - these must not be reported.
 function plainFunctionWithoutParameterType($factor): int
 {

--- a/tests/PHPStan/data/closure-parameter-types.php
+++ b/tests/PHPStan/data/closure-parameter-types.php
@@ -11,3 +11,17 @@ $typedClosureParameter = static function (int $factor): int {
 };
 
 $typedArrowParameter = static fn (int $factor): int => 2 * $factor;
+
+// Only closures are in scope - these must not be reported.
+function plainFunctionWithoutParameterType($factor): int
+{
+    return 2;
+}
+
+class MethodWithoutParameterType
+{
+    public function untyped($factor): int
+    {
+        return 2;
+    }
+}

--- a/tests/PHPStan/data/closure-parameter-types.php
+++ b/tests/PHPStan/data/closure-parameter-types.php
@@ -19,7 +19,6 @@ $missingMultiLineParameters = static function (
     return 2;
 };
 
-// Only closures are in scope - these must not be reported.
 function plainFunctionWithoutParameterType($factor): int
 {
     return 2;

--- a/tests/PHPStan/data/closure-return-types.php
+++ b/tests/PHPStan/data/closure-return-types.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+$missingClosure = static function (int $value) {
+    return $value * 2;
+};
+
+$missingArrow = static fn (int $value) => $value * 2;
+
+$typedClosure = static function (int $value): int {
+    return $value * 2;
+};
+
+$typedArrow = static fn (int $value): int => $value * 2;

--- a/tests/PHPStan/data/closure-return-types.php
+++ b/tests/PHPStan/data/closure-return-types.php
@@ -11,3 +11,17 @@ $typedClosure = static function (int $value): int {
 };
 
 $typedArrow = static fn (int $value): int => $value * 2;
+
+// Only closures are in scope - these must not be reported.
+function plainFunctionWithoutReturnType()
+{
+    return 1;
+}
+
+class MethodWithoutReturnType
+{
+    public function untyped()
+    {
+        return 1;
+    }
+}

--- a/tests/PHPStan/data/closure-return-types.php
+++ b/tests/PHPStan/data/closure-return-types.php
@@ -12,7 +12,6 @@ $typedClosure = static function (int $value): int {
 
 $typedArrow = static fn (int $value): int => $value * 2;
 
-// Only closures are in scope - these must not be reported.
 function plainFunctionWithoutReturnType()
 {
     return 1;


### PR DESCRIPTION
Closures and arrow functions without an explicit return type force readers and static analysis to infer behavior from the implementation. Rector's TYPE_DECLARATION set fixes methods but cannot infer closure types from magic properties (e.g. Eloquent relations), so a dedicated PHPStan rule closes that gap next to the existing `MissingClosureParameterTypehintRule`.

Both rules now share a `ClosureTypehintRule` base. It declares `Node\FunctionLike` as its node type rather than `Node\Expr`, which is semantically what these rules care about; the two measure the same on this repo, so the choice is readability, not speed. The `instanceof` filter in the base is load-bearing — without it both rules fire on every named function, method and PHP 8.4 property hook — so the fixtures include untyped named functions and methods to keep it honest.

The new rule is disabled by default in `rules.neon`, like its parameter counterpart, so consumers can enable it per project or per module. This repo enables both on itself.

`MissingClosureParameterTypehintRule` picks up two fixes along the way, both now covered by fixture cases:

- Arrow functions were reported as "Closure". They are now labelled "Arrow function", matching the new rule. **Consumers who have this rule enabled and a baseline will need to regenerate it.**
- Errors on a multi-line signature all landed on the closure's first line instead of the offending parameter's line.

Rector and php-cs-fixer skip `tests/PHPStan/data` — they kept adding the return types the fixtures must lack, and `use_arrow_functions` collapsed the multi-line closures that distinguish the two node types under test.

`make rector` fails on this branch with `Undefined constant Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_40`. That is pre-existing on `master` and unrelated to this change.